### PR TITLE
add docs url to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,8 @@ Suggests:
     sf,
     testthat
 LinkingTo: Rcpp
-URL: https://github.com/ropensci/osmdata
+URL: https://docs.ropensci.org/osmdata (website)
+    https://github.com/ropensci/osmdata (devel)
 BugReports: https://github.com/ropensci/osmdata/issues
 Encoding: UTF-8
 RoxygenNote: 6.1.1


### PR DESCRIPTION
Hello!

The official [rOpenSci docs server](https://docs.ropensci.org) which we [announced](https://ropensci.org/technotes/2019/06/07/ropensci-docs/) in June is fully ready for production now:

 - Official documentation URL: https://docs.ropensci.org/osmdata
 - Website build logs: https://dev.ropensci.org/job/osmdata (click "last build" -> "console output")

If all seems good, we strongly suggest to add the URL to the package DESCRIPTION file and include this in the next CRAN update. This has two major benefits:

  - Pkgdown does automatic [cross-linking](https://pkgdown.r-lib.org/dev/articles/linking.html) to other pkgdown sites that can be found via CRAN. This means that if another package refers to your package in an example or vignette, their pkgdown site automatically hyperlinks those functions to your pkgdown site (if your pkgdown URL has been published on CRAN!)
  - Because our documentation is hosted under a single official domain `docs.ropensci.org` this will accumulate a higher pagerank than when a site are scattered over github or custom places. This should make it easier to find these documentation sites on Google and others.

We hope that this service will make it easy to maintain high quality and visible documentation for your packages! If something is unclear or not working, feel free to ask questions here or on slack.
