### PR TITLE
use already built query; might close issue #192

### DIFF
--- a/R/getbb.R
+++ b/R/getbb.R
@@ -178,7 +178,7 @@ getbb <- function(place_name,
         print(q_url)
 
     #res <- httr::POST(base_url, query = query, httr::timeout (100))
-    res <- httr::RETRY ("POST", base_url, body = query, times = 10)
+    res <- httr::RETRY("POST", q_url, times = 10)
     txt <- httr::content(res, as = "text", encoding = "UTF-8",
                          type = "application/xml")
     obj <- tryCatch(expr =


### PR DESCRIPTION
I think that the repeated errors described in #192 were introduced by the new httr repeated query introduced in commit 86185db1ab1d0bf2875fe73e18161eca4c959fa7

My bounding box query now works straight away.