### PR TITLE
Update AND and OR examples

### DIFF
--- a/vignettes/osmdata.Rmd
+++ b/vignettes/osmdata.Rmd
@@ -414,7 +414,7 @@ nrow(des_bike_and_bridge$osm_points); nrow(des_bike_and_bridge$osm_lines)
 ## [1] 32
 ```
 
-That query returns only 7 points and 3 lines.  Designed cycleways **OR** bridges
+That query returns only 99 points and 32 lines.  Designed cycleways **OR** bridges
 can be obtained through simply combining multiple `osmdata` objects with the `c`
 operator:
 

--- a/vignettes/osmdata.Rmd
+++ b/vignettes/osmdata.Rmd
@@ -284,8 +284,7 @@ names (dat1) <- names (dat2) <- names (dat) <- c ('osm_points', 'osm_lines',
                                                   'osm_polygons',
                                                   'osm_multilines',
                                                   'osm_multipolygons')
-dat1 <- dat1 [c (1:3, 5)]
-dat1
+dat1 [c (1:3, 5)]
 dat2
 dat
 ```

--- a/vignettes/osmdata.Rmd
+++ b/vignettes/osmdata.Rmd
@@ -277,21 +277,22 @@ unlist (lapply (dat2, nrow) [4:8])
 unlist (lapply (dat, nrow) [4:8])
 ```
 ```{r, echo = FALSE}
-dat1 <- c (51327, 186, 901, 0, 47)
+dat1 <- c (51399, 186, 905, 0, 47)
 dat2 <- c (4473, 55, 4, 1, 3)
-dat <- c (53705, 238, 904, 0, 49)
+dat <- c (53777, 238, 908, 1, 49)
 names (dat1) <- names (dat2) <- names (dat) <- c ('osm_points', 'osm_lines',
                                                   'osm_polygons',
                                                   'osm_multilines',
                                                   'osm_multipolygons')
-dat <- dat [c (1:3, 5)]
+dat1 <- dat1 [c (1:3, 5)]
 dat1
 dat2
 dat
 ```
 The number of resultant objects is less than the sum of the individual
 components because the `c` operator only combines unique objects. There are
-thus, for example, 7,590 points corresponding to objects in Kunming, China that
+thus, for example, `r formatC(unname(dat[1]), format = "d", big.mark = ",")` 
+points corresponding to objects in Kunming, China that
 are **either** natural waterbodies **or** that include 'Dian' in their English
 name.  Compare this with the result of the equivalent `AND` operation
 ```{r, eval = FALSE}
@@ -305,7 +306,8 @@ names (dat1) <- names (dat2) <- names (dat) <- c ('osm_points', 'osm_lines',
                                                   'osm_multipolygons')
 dat
 ```
-And there are, for example, the considerably lower number of 2,029 points
+And there are, for example, the considerably lower number of 
+`r formatC(unname(dat[1]), format = "d", big.mark = ",")` points
 describing objects in Kunming that are **both** natural waterbodies **and** that
 include 'Dian' in their English name.
 


### PR DESCRIPTION
Hi! I update the examples in the vignette according to your explanation in #186. 

In particular, when you define `dat <- c (53777, 238, 908, 1, 49)` I think you should set the number of multilinestrings equal to 1 instead of 0 and exclude the multilinestring output just from `dat1`, i.e. `dat1 <- dat1 [c (1:3, 5)]` instead of `dat <- dat [c (1:3, 5)]`. 

The other change is used to automatically update the description of the examples using R code instead of fixed numeric input. I'm not sure if it works on the online vignette or if you like that so I changed that only in two places but I could provide more commits if you thinks it's a good idea. 

