### PR TITLE
Add note about OSM's licence

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -227,6 +227,13 @@ function.  Full package functionality is described on the
 citation ("osmdata")
 ```
 
+## Data licensing
+
+All data that you access using `osmdata` is licensed under
+[OpenStreetMap's license, the Open Database Licence](https://wiki.osmfoundation.org/wiki/Licence).
+You should make sure you understand that licence before publishing any derived datasets.
+
+
 ## Code of Conduct
 
 Please note that this project is released with a [Contributor Code of

--- a/README.md
+++ b/README.md
@@ -251,6 +251,13 @@ citation ("osmdata")
 #>   }
 ```
 
+## Data licensing
+
+All data that you access using `osmdata` is licensed under
+[OpenStreetMap's license, the Open Database Licence](https://wiki.osmfoundation.org/wiki/Licence).
+You should make sure you understand that licence before publishing any derived datasets.
+
+
 ## Code of Conduct
 
 Please note that this project is released with a [Contributor Code of


### PR DESCRIPTION
We can't assume that every user of R `osmdata` will have realised that OSM's data has a particular licence, with implications for how they may re-use it. It is responsible to add a brief note about this.