### PR TITLE
fix code style for unname_osmdata_sf

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,6 @@
 #' unname_osmdata_sf
 #'
-#' Remove names from 'osmdata` geometry objects, for cases in which these cause
+#' Remove names from `osmdata` geometry objects, for cases in which these cause
 #' issues, particularly with plotting, such as
 #' \url{https://github.com/rstudio/leaflet/issues/631}, or
 #' \url{https://github.com/r-spatial/sf/issues/1177}. Note that removing these


### PR DESCRIPTION
I was reading the documentation for `unname_osmdata_sf` and spotted a small issue with documentation, i.e. missing initial \` when refering to `osmdata`