### PR TITLE
Fix print method to invisibly return x

### DIFF
--- a/R/osmdata-methods.R
+++ b/R/osmdata-methods.R
@@ -24,6 +24,7 @@ print.osmdata <- function (x, ...) {
         msg <- msg_non_sf (msg, x)
 
     message (msg)
+    invisible (x)
 }
 
 msg_sf <- function (msg, x) {

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -98,6 +98,7 @@ test_that ("make_query", {
 
         if (test_all) {
             res <- osmdata_sp (qry)
+            expect_equal (res, print (res))
             expect_message (print (res), "Object of class 'osmdata' with")
             expect_silent (res <- osmdata_sp (qry, doc))
             expect_message (print (res), "Object of class 'osmdata' with")


### PR DESCRIPTION
Fixes #235, updated the `print.osmdata` method to return x invisibly.

Added test for this expectation.