### PR TITLE
Document differences between `add_osm_feature` and `add_osm_features`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: osmdata
 Title: Import 'OpenStreetMap' Data as Simple Features or Spatial Objects
 Version: 0.1.6.008
-Authors@R: 
+Authors@R:
     c(person(given = "Mark",
              family = "Padgham",
              role = c("aut", "cre"),
@@ -26,6 +26,9 @@ Authors@R:
              role = "ctb"),
       person(given = "Enrico",
              family = "Spinielli",
+             role = "ctb"),
+      person(given = "Anthony",
+             family = "North",
              role = "ctb"),
       person(given = "Marcin",
              family = "Kalicinski",
@@ -70,14 +73,14 @@ Suggests:
     rmarkdown,
     sf,
     testthat
-LinkingTo: 
+LinkingTo:
     Rcpp
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Encoding: UTF-8
 NeedsCompilation: yes
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 SystemRequirements: C++11
 X-schema.org-applicationCategory: Data Access
 X-schema.org-isPartOf: https://ropensci.org

--- a/R/opq.R
+++ b/R/opq.R
@@ -181,6 +181,18 @@ paste_features <- function (key, value, key_pre = "", bind = "=",
 #' \link{opq_string}.
 #'
 #' @references <https://wiki.openstreetmap.org/wiki/Map_Features>
+#' @seealso [add_osm_features]
+#'
+#' @section `add_osm_feature` vs `add_osm_features`:
+#' Features defined within an [add_osm_features] call are combined with a
+#' logical OR.
+#'
+#' Chained calls to either [add_osm_feature] or `add_osm_features()` combines
+#' features from these calls in a logical AND; this is analagous to chaining
+#' `dplyr::filter()` on a data frame.
+#'
+#' `add_osm_features()` with only one feature is logically equivalent to
+#' `add_osm_feature()`.
 #'
 #' @export
 #'
@@ -261,6 +273,7 @@ add_osm_feature <- function (opq,
 #' \url{https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#By_tag_.28has-kv.29}.
 #'
 #' @inheritParams add_osm_feature
+#' @inheritSection add_osm_feature `add_osm_feature` vs `add_osm_features`
 #' @param features Character vector of key-value pairs with keys and values
 #' enclosed in escape-formatted quotations (see examples).
 #' @param bbox optional bounding box for the feature query; must be set if no
@@ -268,6 +281,7 @@ add_osm_feature <- function (opq,
 #' @return \link{opq} object
 #'
 #' @references <https://wiki.openstreetmap.org/wiki/Map_Features>
+#' @seealso [add_osm_feature]
 #'
 #' @export
 #'
@@ -469,7 +483,7 @@ opq_string_intern <- function (opq, quiet = TRUE) {
             features <- paste0 (sprintf (" node %s (%s);\n",
                                          features,
                                          opq$bbox))
-        
+
         } else if (!is.null (attr (opq, "enclosing"))) {
 
             if (length (features) > 1)

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ropensci/osmdata/",
   "issueTracker": "https://github.com/ropensci/osmdata/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.6.008",
+  "version": "0.1.6.8",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -66,6 +66,11 @@
       "@type": "Person",
       "givenName": "Enrico",
       "familyName": "Spinielli"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Anthony",
+      "familyName": "North"
     },
     {
       "@type": "Person",
@@ -327,28 +332,12 @@
   ],
   "applicationCategory": "DataAccess",
   "isPartOf": "https://ropensci.org",
-  "keywords": [
-    "open0street0map",
-    "openstreetmap",
-    "overpass0API",
-    "OSM",
-    "overpass-api",
-    "r",
-    "cpp",
-    "rstats",
-    "osm",
-    "osm-data",
-    "r-package",
-    "peer-reviewed"
-  ],
-  "contIntegration": [
-    "https://github.com/ropensci/osmdata/actions?query=workflow%3AR-CMD-check",
-    "https://codecov.io/gh/ropensci/osmdata"
-  ],
+  "keywords": ["open0street0map", "openstreetmap", "overpass0API", "OSM", "overpass-api", "r", "cpp", "rstats", "osm", "osm-data", "r-package", "peer-reviewed"],
+  "contIntegration": ["https://github.com/ropensci/osmdata/actions?query=workflow%3AR-CMD-check", "https://codecov.io/gh/ropensci/osmdata"],
   "developmentStatus": "https://www.repostatus.org/#active",
   "releaseNotes": "https://github.com/ropensci/osmdata/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/osmdata/blob/main/README.md",
-  "fileSize": "7739.766KB",
+  "fileSize": "20531.507KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",
@@ -385,10 +374,7 @@
         "issueNumber": "14",
         "datePublished": "2017",
         "isPartOf": {
-          "@type": [
-            "PublicationVolume",
-            "Periodical"
-          ],
+          "@type": ["PublicationVolume", "Periodical"],
           "volumeNumber": "2",
           "name": "The Journal of Open Source Software"
         }

--- a/man/add_osm_feature.Rd
+++ b/man/add_osm_feature.Rd
@@ -49,6 +49,19 @@ of regular expressions on OSM keys, as described in Section 6.1.5 of
 query submitted to the overpass API can be obtained from
 \link{opq_string}.
 }
+\section{\code{add_osm_feature} vs \code{add_osm_features}}{
+
+Features defined within an \link{add_osm_features} call are combined with a
+logical OR.
+
+Chained calls to either \link{add_osm_feature} or \code{add_osm_features()} combines
+features from these calls in a logical AND; this is analagous to chaining
+\code{dplyr::filter()} on a data frame.
+
+\code{add_osm_features()} with only one feature is logically equivalent to
+\code{add_osm_feature()}.
+}
+
 \examples{
 \dontrun{
 q <- opq ("portsmouth usa") \%>\%
@@ -69,4 +82,7 @@ q <- opq ("portsmouth uk") \%>\%
 }
 \references{
 \url{https://wiki.openstreetmap.org/wiki/Map_Features}
+}
+\seealso{
+\link{add_osm_features}
 }

--- a/man/add_osm_features.Rd
+++ b/man/add_osm_features.Rd
@@ -24,6 +24,19 @@ with multiple features. Key-value matching may be controlled by using
 the filter symbols described in
 \url{https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#By_tag_.28has-kv.29}.
 }
+\section{\code{add_osm_feature} vs \code{add_osm_features}}{
+
+Features defined within an \link{add_osm_features} call are combined with a
+logical OR.
+
+Chained calls to either \link{add_osm_feature} or \code{add_osm_features()} combines
+features from these calls in a logical AND; this is analagous to chaining
+\code{dplyr::filter()} on a data frame.
+
+\code{add_osm_features()} with only one feature is logically equivalent to
+\code{add_osm_feature()}.
+}
+
 \examples{
 \dontrun{
 q <- opq ("portsmouth usa") \%>\%
@@ -40,4 +53,7 @@ c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
 }
 \references{
 \url{https://wiki.openstreetmap.org/wiki/Map_Features}
+}
+\seealso{
+\link{add_osm_feature}
 }


### PR DESCRIPTION
Adds a documentation section to `add_osm_feature` and `add_osm_features` that briefly explains how the two functions differ.

closes #240 