### PR TITLE
Warning for trim_osmdata function

### DIFF
--- a/R/trim-osmdata.R
+++ b/R/trim-osmdata.R
@@ -16,6 +16,10 @@
 #'
 #' @note It will generally be necessary to pre-load the \pkg{sf} package for
 #' this function to work correctly.
+#' @note Caution is advised when using polygons obtained from Nominatim via 
+#' getbb(..., format_out = "polygon"|"sf_polygon"). These shapes can be outdated 
+#' and thus could cause the trimming operation to not give results expected 
+#' based on the current state of the OSM data.
 #'
 #' @family transform
 #' @export

--- a/man/trim_osmdata.Rd
+++ b/man/trim_osmdata.Rd
@@ -28,6 +28,11 @@ Trim an \link{osmdata} object to within a bounding polygon
 \note{
 It will generally be necessary to pre-load the \pkg{sf} package for
 this function to work correctly.
+
+Caution is advised when using polygons obtained from Nominatim via
+getbb(..., format_out = "polygon"|"sf_polygon"). These shapes can be outdated
+and thus could cause the trimming operation to not give results expected
+based on the current state of the OSM data.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
This is adding a warning Note to `trim_osmdata()` help page about possible problems with polygons downloaded from Nominatim.
Discussed previously in #253