### PR TITLE
update `add_osm_features()` per #277 + minor bugfix for `available_tags()` + possible `opq_osm_id()` feature addition

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,9 @@ Authors@R: c(
     person("Anthony", "North", role = "ctb"),
     person("Martin", "Machyna", role = "ctb"),
     person("Marcin", "Kalicinski", role = c("ctb", "cph"),
-           comment = "Author of included RapidXML code")
+           comment = "Author of included RapidXML code"),
+    person("Eli", "Pousson", , "eli.pousson@gmail.com", role = c("ctb"),
+           comment = c(ORCID = "0000-0001-8280-1706"))
   )
 Maintainer: Mark Padgham <mark.padgham@email.com>
 Description: Download and import of 'OpenStreetMap' ('OSM') data as 'sf'

--- a/R/features.R
+++ b/R/features.R
@@ -107,7 +107,7 @@ available_tags <- function (feature) {
 
             taglists <- mapply (unique, taglists)
             ret <- taglists [[feature]] %>% sort ()
-            ret <- gsub ("&.+", "", ret)
+            ret <- gsub ("&.*$", "", ret)
         }
     } else {
         message ("No internet connection")

--- a/R/features.R
+++ b/R/features.R
@@ -107,6 +107,7 @@ available_tags <- function (feature) {
 
             taglists <- mapply (unique, taglists)
             ret <- taglists [[feature]] %>% sort ()
+            ret <- gsub ("&.+", "", ret)
         }
     } else {
         message ("No internet connection")

--- a/R/opq.R
+++ b/R/opq.R
@@ -241,46 +241,46 @@ add_osm_feature <- function (opq,
                              value_exact = TRUE,
                              match_case = TRUE,
                              bbox = NULL) {
-  if (missing(key)) {
-    stop("key must be provided")
-  }
-  
-  if (is.null(bbox) & is.null(opq$bbox)) {
-    stop("Bounding box has to either be set in opq or must be set here")
-  }
-  
-  if (is.null(bbox)) {
-    bbox <- opq$bbox
-  } else {
-    bbox <- bbox_to_string(bbox)
-    opq$bbox <- bbox
-  }
-  
-  bind_key_pre <- set_bind_key_pre(key_exact, value_exact)
-  
-  if (missing(value)) {
-    value <- NULL
-  }
-  
-  feature <- paste_features(
-    key, value, bind_key_pre$key_pre, bind_key_pre$bind,
-    match_case, value_exact
-  )
-  
-  opq$features <- paste0(c(opq$features, feature), collapse = "")
-  
-  if (is.null(opq$suffix)) {
-    opq$suffix <- ");\n(._;>;);\nout body;"
-  }
-  # opq$suffix <- ");\n(._;>);\nout qt body;"
-  # qt option is not compatible with sf because GDAL requires nodes to be
-  # numerically sorted
-  
-  opq
+    if (missing (key)) {
+        stop ("key must be provided")
+    }
+
+    if (is.null (bbox) & is.null (opq$bbox)) {
+        stop ("Bounding box has to either be set in opq or must be set here")
+    }
+
+    if (is.null (bbox)) {
+        bbox <- opq$bbox
+    } else {
+        bbox <- bbox_to_string (bbox)
+        opq$bbox <- bbox
+    }
+
+    bind_key_pre <- set_bind_key_pre (key_exact, value_exact)
+
+    if (missing (value)) {
+        value <- NULL
+    }
+
+    feature <- paste_features (
+        key, value, bind_key_pre$key_pre, bind_key_pre$bind,
+        match_case, value_exact
+    )
+
+    opq$features <- paste0 (c (opq$features, feature), collapse = "")
+
+    if (is.null (opq$suffix)) {
+        opq$suffix <- ");\n(._;>;);\nout body;"
+    }
+    # opq$suffix <- ");\n(._;>);\nout qt body;"
+    # qt option is not compatible with sf because GDAL requires nodes to be
+    # numerically sorted
+
+    opq
 }
 
 #' Get conditional operator/prefix values based on value_exact and key_exact
-#' 
+#'
 #' @param bind Operator used to combine key and value. Options include "="
 #'   (default - equivalent to `value_exact = TRUE`), "!=", "~" (equivalent to
 #'   `value_exact = FALSE`), or "!~".
@@ -291,83 +291,83 @@ set_bind_key_pre <- function (key_exact = TRUE,
                               features = NULL,
                               bind = "=",
                               key_pre = "") {
-  if (!is.null(value_exact)) {
-    value_exact <- check_value_exact(value_exact, key_exact)
-  }
-  
-  check_bind_key_pre(bind, key_pre)
-  
-  if (!is.null(features)) {
-    if (length(bind) == 1) {
-      bind <- rep_len(bind, length(features))
-    } else if (!identical_length(features, bind)) {
-      stop(
-        "bind must be length 1 or the same length as features"
-      )
+    if (!is.null (value_exact)) {
+        value_exact <- check_value_exact (value_exact, key_exact)
     }
-    
-    if (length(key_pre) == 1) {
-      key_pre <- rep_len(key_pre, length(features))
-    } else if (!identical_length(features, key_pre)) {
-      stop(
-        "key_pre must be length 1 or the same length as features"
-      )
+
+    check_bind_key_pre (bind, key_pre)
+
+    if (!is.null (features)) {
+        if (length (bind) == 1) {
+            bind <- rep_len (bind, length (features))
+        } else if (!identical_length (features, bind)) {
+            stop (
+                "bind must be length 1 or the same length as features"
+            )
+        }
+
+        if (length (key_pre) == 1) {
+            key_pre <- rep_len (key_pre, length (features))
+        } else if (!identical_length (features, key_pre)) {
+            stop (
+                "key_pre must be length 1 or the same length as features"
+            )
+        }
     }
-  }
-  
-  features_len <- 1L
-  if (!is.null(features)) {
-    features_len <- length(features)
-  }
-  
-  if (!is.null(value_exact) && !value_exact) {
-    bind <- rep_len("~", features_len)
-  }
-  
-  if (!is.null(key_exact) && !key_exact) {
-    key_pre <- rep_len("~", features_len)
-  }
-  
-  list(
-    "bind" = bind,
-    "key_pre" = key_pre
-  )
+
+    features_len <- 1L
+    if (!is.null (features)) {
+        features_len <- length (features)
+    }
+
+    if (!is.null (value_exact) && !value_exact) {
+        bind <- rep_len ("~", features_len)
+    }
+
+    if (!is.null (key_exact) && !key_exact) {
+        key_pre <- rep_len ("~", features_len)
+    }
+
+    list (
+        "bind" = bind,
+        "key_pre" = key_pre
+    )
 }
 
 #' Are x and y an identical length?
 #'
 #' @noRd
 identical_length <- function (x, y) {
-  identical(length(x), length(y))
+    identical (length (x), length (y))
 }
 
 #' Check that value_exact can be combined with key_exact
 #'
 #' @noRd
 check_value_exact <- function (value_exact = TRUE, key_exact = TRUE) {
-  if (value_exact && !key_exact) {
-    message(
-      "key_exact = FALSE can only combined with ",
-      "value_exact = FALSE; setting value_exact = FALSE"
-    )
-    
-    return(FALSE)
-  }
-  
-  value_exact
+    if (value_exact && !key_exact) {
+        message (
+            "key_exact = FALSE can only combined with ",
+            "value_exact = FALSE; setting value_exact = FALSE"
+        )
+
+        return (FALSE)
+    }
+
+    value_exact
 }
 
 #' Check for valid bind and key_pre values
 #'
 #' @noRd
 check_bind_key_pre <- function (bind = "=", key_pre = "") {
-  if (!all(bind %in% c("=", "!=", "~", "!~"))) {
-    stop('bind must only include "=", "!=", "~", or "!~"')
-  }
-  
-  if (!all(key_pre %in% c("", "~"))) {
-    stop('key_pre must only include "" or "~"')
-  }
+    if (!all (bind %in% c ("=", "!=", "~", "!~"))) {
+        stop ('bind must only include "=", "!=", "~", or "!~"')
+    }
+
+    if (!all (key_pre %in% c ("", "~"))) {
+        stop ('key_pre must only include "" or "~"')
+    }
 }
 
 #' Add multiple features to an Overpass query
@@ -396,104 +396,104 @@ check_bind_key_pre <- function (bind = "=", key_pre = "") {
 #' @examples
 #' \dontrun{
 #' q <- opq ("portsmouth usa") %>%
-#'   add_osm_features (features = list(
-#'     "amenity" = "restaurant",
-#'     "amenity" = "pub"
-#'   ))
+#'     add_osm_features (features = list (
+#'         "amenity" = "restaurant",
+#'         "amenity" = "pub"
+#'     ))
 #'
 #' q <- opq ("portsmouth usa") %>%
-#'   add_osm_features (features = c(
-#'     "\"amenity\"=\"restaurant\"",
-#'     "\"amenity\"=\"pub\""
-#'   ))
+#'     add_osm_features (features = c (
+#'         "\"amenity\"=\"restaurant\"",
+#'         "\"amenity\"=\"pub\""
+#'     ))
 #' # This extracts in a single query the same result as the following:
 #' q1 <- opq ("portsmouth usa") %>%
-#'   add_osm_feature (
-#'     key = "amenity",
-#'     value = "restaurant"
-#'   )
+#'     add_osm_feature (
+#'         key = "amenity",
+#'         value = "restaurant"
+#'     )
 #' q2 <- opq ("portsmouth usa") %>%
-#'   add_osm_feature (key = "amenity", value = "pub")
-#' c(osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
+#'     add_osm_feature (key = "amenity", value = "pub")
+#' c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
 #' }
 add_osm_features <- function (opq,
                               features,
                               bbox = NULL,
                               key_exact = TRUE,
                               value_exact = TRUE) {
-  if (is.null(bbox) & is.null(opq$bbox)) {
-    stop("Bounding box has to either be set in opq or must be set here")
-  }
-  
-  if (is.null(bbox)) {
-    bbox <- opq$bbox
-  } else {
-    bbox <- bbox_to_string(bbox)
-    opq$bbox <- bbox
-  }
-  
-  if (is.null(opq$suffix)) {
-    opq$suffix <- ");\n(._;>;);\nout body;"
-  }
-  
-  check_features(features)
-  
-  if (is_named(features)) {
-    bind_key_pre <-
-      set_bind_key_pre(
-        features = features,
-        value_exact = value_exact,
-        key_exact = key_exact
-      )
-    
-    features <-
-      paste0(
-        bind_key_pre$key_pre, '\"', names(features), '\"',
-        bind_key_pre$bind, '\"', features, '\"'
-      )
-  }
-  
-  index <- which(!grepl("^\\[", features))
-  features[index] <- paste0(" [", features[index])
-  index <- which(!grepl("\\]$", features))
-  features[index] <- paste0(features[index], "]")
-  
-  opq$features <- features
-  
-  opq
+    if (is.null (bbox) & is.null (opq$bbox)) {
+        stop ("Bounding box has to either be set in opq or must be set here")
+    }
+
+    if (is.null (bbox)) {
+        bbox <- opq$bbox
+    } else {
+        bbox <- bbox_to_string (bbox)
+        opq$bbox <- bbox
+    }
+
+    if (is.null (opq$suffix)) {
+        opq$suffix <- ");\n(._;>;);\nout body;"
+    }
+
+    check_features (features)
+
+    if (is_named (features)) {
+        bind_key_pre <-
+            set_bind_key_pre (
+                features = features,
+                value_exact = value_exact,
+                key_exact = key_exact
+            )
+
+        features <-
+            paste0 (
+                bind_key_pre$key_pre, '\"', names (features), '\"',
+                bind_key_pre$bind, '\"', features, '\"'
+            )
+    }
+
+    index <- which (!grepl ("^\\[", features))
+    features [index] <- paste0 (" [", features [index])
+    index <- which (!grepl ("\\]$", features))
+    features [index] <- paste0 (features [index], "]")
+
+    opq$features <- features
+
+    opq
 }
 
 #' Is features a named list or character vector?
-#' 
+#'
 #' @noRd
 is_named <- function (x) {
-  !is.null(names(x)) && !any("" %in% names(x))
+    !is.null (names (x)) && !any ("" %in% names (x))
 }
 
 #' Is features an escape-delimited string?
-#' 
+#'
 #' @noRd
 is_escape_delimited <- function (x) {
-  length(which(!grepl("\\\"", x))) > 0L
+    length (which (!grepl ("\\\"", x))) > 0L
 }
 
 #' Check if features is provided and uses the required class and formatting
-#' 
+#'
 #' @noRd
 check_features <- function (features) {
-  if (missing(features)) {
-    stop("features must be provided")
-  }
-  
-  stopifnot(
-    "features must be a list or character vector." = is.character(features) | is.list(features)
-  )
-  
-  if (!is_named(features) && is_escape_delimited(features)) {
-    stop(
-      "features must be a named list or vector or a character vector enclosed in escape delimited quotations (see examples)"
+    if (missing (features)) {
+        stop ("features must be provided")
+    }
+
+    stopifnot (
+        "features must be a list or character vector." = is.character (features) | is.list (features)
     )
-  }
+
+    if (!is_named (features) && is_escape_delimited (features)) {
+        stop (
+            "features must be a named list or vector or a character vector enclosed in escape delimited quotations (see examples)"
+        )
+    }
 }
 
 #' Add a feature specified by OSM ID to an Overpass query
@@ -534,32 +534,32 @@ check_features <- function (features) {
 #' dat <- c (dat1, dat2) # The node and way data combined
 #' }
 opq_osm_id <- function (id = NULL, type = NULL, open_url = FALSE) {
-  if (is.null(type)) {
-    if (is.null(id) ) {
-      stop(
-        "type must be specified: one of node, way, or relation if id is 'NULL'"
-      )
-    } else if ((length(id) == 1L) && grepl("^node/|^way/|^relation/", id)) {
-      type <- dirname(id)
-      id <- basename(id)
+    if (is.null (type)) {
+        if (is.null (id)) {
+            stop (
+                "type must be specified: one of node, way, or relation if id is 'NULL'"
+            )
+        } else if ((length (id) == 1L) && grepl ("^node/|^way/|^relation/", id)) {
+            type <- dirname (id)
+            id <- basename (id)
+        }
     }
-  }
-  
-  type <- match.arg(tolower(type), c("node", "way", "relation"))
-  
-  if (is.null(id)) {
-    stop("id must be specified.")
-  }
-  if (!(is.character(id) | storage.mode(id) == "double")) {
-    stop("id must be character or numeric.")
-  }
-  if (length(id) != 1L) {
-    stop("Only a single id may be entered.")
-  }
-  
-  if (!is.character(id)) {
-    id <- paste0(id)
-  }
+
+    type <- match.arg (tolower (type), c ("node", "way", "relation"))
+
+    if (is.null (id)) {
+        stop ("id must be specified.")
+    }
+    if (!(is.character (id) | storage.mode (id) == "double")) {
+        stop ("id must be character or numeric.")
+    }
+    if (length (id) != 1L) {
+        stop ("Only a single id may be entered.")
+    }
+
+    if (!is.character (id)) {
+        id <- paste0 (id)
+    }
 
     opq <- opq (1:4)
     opq$bbox <- NULL

--- a/R/opq.R
+++ b/R/opq.R
@@ -280,6 +280,11 @@ add_osm_feature <- function (opq,
 }
 
 #' Get conditional operator/prefix values based on value_exact and key_exact
+#' 
+#' @param bind Operator used to combine key and value. Options include "="
+#'   (default - equivalent to `value_exact = TRUE`), "!=", "~" (equivalent to
+#'   `value_exact = FALSE`), or "!~".
+#' @param key_pre Prefix for key. Options include "" or "~".
 #' @noRd
 set_bind_key_pre <- function (key_exact = TRUE,
                               value_exact = TRUE,
@@ -380,9 +385,6 @@ check_bind_key_pre <- function (bind = "=", key_pre = "") {
 #'   examples for details.
 #' @param bbox optional bounding box for the feature query; must be set if no
 #'        opq query bbox has been set.
-#' @param bind Operator used to combine key and value. Options include "="
-#'   (default - equivalent to `value_exact = TRUE`), "!=", "~" (equivalent to
-#'   `value_exact = FALSE`), or "!~".
 #' @return \link{opq} object
 #'
 #' @references \url{https://wiki.openstreetmap.org/wiki/Map_Features}
@@ -393,26 +395,26 @@ check_bind_key_pre <- function (bind = "=", key_pre = "") {
 #'
 #' @examples
 #' \dontrun{
-#' q <- opq("portsmouth usa") %>%
-#'   add_osm_features(features = list(
+#' q <- opq ("portsmouth usa") %>%
+#'   add_osm_features (features = list(
 #'     "amenity" = "restaurant",
 #'     "amenity" = "pub"
 #'   ))
 #'
-#' q <- opq("portsmouth usa") %>%
-#'   add_osm_features(features = c(
+#' q <- opq ("portsmouth usa") %>%
+#'   add_osm_features (features = c(
 #'     "\"amenity\"=\"restaurant\"",
 #'     "\"amenity\"=\"pub\""
 #'   ))
 #' # This extracts in a single query the same result as the following:
-#' q1 <- opq("portsmouth usa") %>%
-#'   add_osm_feature(
+#' q1 <- opq ("portsmouth usa") %>%
+#'   add_osm_feature (
 #'     key = "amenity",
 #'     value = "restaurant"
 #'   )
-#' q2 <- opq("portsmouth usa") %>%
-#'   add_osm_feature(key = "amenity", value = "pub")
-#' c(osmdata_sf(q1), osmdata_sf(q2)) # all restaurants OR pubs
+#' q2 <- opq ("portsmouth usa") %>%
+#'   add_osm_feature (key = "amenity", value = "pub")
+#' c(osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
 #' }
 add_osm_features <- function (opq,
                               features,

--- a/man/add_osm_features.Rd
+++ b/man/add_osm_features.Rd
@@ -26,10 +26,6 @@ opq query bbox has been set.}
 \url{https://wiki.openstreetmap.org/wiki/Overpass_API}}
 
 \item{value_exact}{If FALSE, \code{value} is not interpreted exactly}
-
-\item{bind}{Operator used to combine key and value. Options include "="
-(default - equivalent to \code{value_exact = TRUE}), "!=", "~" (equivalent to
-\code{value_exact = FALSE}), or "!~".}
 }
 \value{
 \link{opq} object
@@ -55,26 +51,26 @@ features from these calls in a logical AND; this is analagous to chaining
 
 \examples{
 \dontrun{
-q <- opq("portsmouth usa") \%>\%
-  add_osm_features(features = list(
+q <- opq ("portsmouth usa") \%>\%
+  add_osm_features (features = list(
     "amenity" = "restaurant",
     "amenity" = "pub"
   ))
 
-q <- opq("portsmouth usa") \%>\%
-  add_osm_features(features = c(
+q <- opq ("portsmouth usa") \%>\%
+  add_osm_features (features = c(
     "\"amenity\"=\"restaurant\"",
     "\"amenity\"=\"pub\""
   ))
 # This extracts in a single query the same result as the following:
-q1 <- opq("portsmouth usa") \%>\%
-  add_osm_feature(
+q1 <- opq ("portsmouth usa") \%>\%
+  add_osm_feature (
     key = "amenity",
     value = "restaurant"
   )
-q2 <- opq("portsmouth usa") \%>\%
-  add_osm_feature(key = "amenity", value = "pub")
-c(osmdata_sf(q1), osmdata_sf(q2)) # all restaurants OR pubs
+q2 <- opq ("portsmouth usa") \%>\%
+  add_osm_feature (key = "amenity", value = "pub")
+c(osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
 }
 }
 \references{

--- a/man/add_osm_features.Rd
+++ b/man/add_osm_features.Rd
@@ -4,16 +4,32 @@
 \alias{add_osm_features}
 \title{Add multiple features to an Overpass query}
 \usage{
-add_osm_features(opq, features, bbox = NULL)
+add_osm_features(
+  opq,
+  features,
+  bbox = NULL,
+  key_exact = TRUE,
+  value_exact = TRUE
+)
 }
 \arguments{
 \item{opq}{An \code{overpass_query} object}
 
-\item{features}{Character vector of key-value pairs with keys and values
-enclosed in escape-formatted quotations (see examples).}
+\item{features}{A named list or vector with the format \code{list("<key>" = "<value>")} or \code{c("<key>" = "<value>")} or a character vector of key-value
+pairs with keys and values enclosed in escape-formatted quotations. See
+examples for details.}
 
 \item{bbox}{optional bounding box for the feature query; must be set if no
-opq query bbox has been set}
+opq query bbox has been set.}
+
+\item{key_exact}{If FALSE, \code{key} is not interpreted exactly; see
+\url{https://wiki.openstreetmap.org/wiki/Overpass_API}}
+
+\item{value_exact}{If FALSE, \code{value} is not interpreted exactly}
+
+\item{bind}{Operator used to combine key and value. Options include "="
+(default - equivalent to \code{value_exact = TRUE}), "!=", "~" (equivalent to
+\code{value_exact = FALSE}), or "!~".}
 }
 \value{
 \link{opq} object
@@ -39,20 +55,26 @@ features from these calls in a logical AND; this is analagous to chaining
 
 \examples{
 \dontrun{
-q <- opq ("portsmouth usa") \%>\%
-    add_osm_features (features = c (
-        "\"amenity\"=\"restaurant\"",
-        "\"amenity\"=\"pub\""
-    ))
+q <- opq("portsmouth usa") \%>\%
+  add_osm_features(features = list(
+    "amenity" = "restaurant",
+    "amenity" = "pub"
+  ))
+
+q <- opq("portsmouth usa") \%>\%
+  add_osm_features(features = c(
+    "\"amenity\"=\"restaurant\"",
+    "\"amenity\"=\"pub\""
+  ))
 # This extracts in a single query the same result as the following:
-q1 <- opq ("portsmouth usa") \%>\%
-    add_osm_feature (
-        key = "amenity",
-        value = "restaurant"
-    )
-q2 <- opq ("portsmouth usa") \%>\%
-    add_osm_feature (key = "amenity", value = "pub")
-c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
+q1 <- opq("portsmouth usa") \%>\%
+  add_osm_feature(
+    key = "amenity",
+    value = "restaurant"
+  )
+q2 <- opq("portsmouth usa") \%>\%
+  add_osm_feature(key = "amenity", value = "pub")
+c(osmdata_sf(q1), osmdata_sf(q2)) # all restaurants OR pubs
 }
 }
 \references{

--- a/man/add_osm_features.Rd
+++ b/man/add_osm_features.Rd
@@ -52,25 +52,25 @@ features from these calls in a logical AND; this is analagous to chaining
 \examples{
 \dontrun{
 q <- opq ("portsmouth usa") \%>\%
-  add_osm_features (features = list(
-    "amenity" = "restaurant",
-    "amenity" = "pub"
-  ))
+    add_osm_features (features = list (
+        "amenity" = "restaurant",
+        "amenity" = "pub"
+    ))
 
 q <- opq ("portsmouth usa") \%>\%
-  add_osm_features (features = c(
-    "\"amenity\"=\"restaurant\"",
-    "\"amenity\"=\"pub\""
-  ))
+    add_osm_features (features = c (
+        "\"amenity\"=\"restaurant\"",
+        "\"amenity\"=\"pub\""
+    ))
 # This extracts in a single query the same result as the following:
 q1 <- opq ("portsmouth usa") \%>\%
-  add_osm_feature (
-    key = "amenity",
-    value = "restaurant"
-  )
+    add_osm_feature (
+        key = "amenity",
+        value = "restaurant"
+    )
 q2 <- opq ("portsmouth usa") \%>\%
-  add_osm_feature (key = "amenity", value = "pub")
-c(osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
+    add_osm_feature (key = "amenity", value = "pub")
+c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
 }
 }
 \references{

--- a/man/opq_osm_id.Rd
+++ b/man/opq_osm_id.Rd
@@ -9,9 +9,11 @@ opq_osm_id(id = NULL, type = NULL, open_url = FALSE)
 \arguments{
 \item{id}{One or more official OSM identifiers (long-form integers), which
 must be entered as either a character or \emph{numeric} value (because R does not
-support long-form integers).}
+support long-form integers). id can also be a character string prefixed with
+the id type, e.g. "relation/11158003"}
 
-\item{type}{Type of object; must be either \code{node}, \code{way}, or \code{relation}}
+\item{type}{Type of object; must be either \code{node}, \code{way}, or \code{relation}.
+Optional if id is prefixed with the type.}
 
 \item{open_url}{If \code{TRUE}, open the OSM page of the specified object in web
 browser. Multiple objects (\code{id} values) will be opened in multiple pages.}

--- a/tests/testthat/test-opq.R
+++ b/tests/testthat/test-opq.R
@@ -115,7 +115,7 @@ test_that ("opq_osm_id", {
 
     expect_error (
         q <- opq_osm_id (),
-        "type must be specified: one of node, way, or relation"
+        "type must be specified: one of node, way, or relation if id is 'NULL'"
     )
     expect_error (
         opq_osm_id (type = "a"),
@@ -132,6 +132,10 @@ test_that ("opq_osm_id", {
     expect_error (
         opq_osm_id (type = "node", id = 1:2 + 0.1),
         "Only a single id may be entered."
+    )
+    expect_identical(
+      opq_osm_id (type = "node", id = 123456),
+      opq_osm_id (id = "node/123456")
     )
     expect_s3_class (
         x <- opq_osm_id (type = "node", id = 123456),

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -217,12 +217,10 @@ test_that ("add_osm_features", {
     )
 
     qry <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517))
+    
     expect_error (
-        qry <- add_osm_features (qry, features = "a"),
-        paste0 (
-            "features must be enclosed in escape-delimited ",
-            "quotations \\(see example\\)"
-        )
+       qry <- add_osm_features (qry, features = "a"),
+        "features must be a named list or vector or a character vector enclosed in escape delimited quotations \\(see examples\\)"
     )
 
     bbox <- c (-0.118, 51.514, -0.115, 51.517)
@@ -235,4 +233,16 @@ test_that ("add_osm_features", {
     )
     expect_false (identical (qry1$bbox, qry2$bbox))
 
+    qry3 <- add_osm_features (qry0, features = c("amenity" = "restaurant"))
+    expect_identical (qry1, qry3)
+    
+    qry4 <- add_osm_features (qry0,
+      features = c("amenity" = "restaurant", "amentity" = "pub")
+      )
+    expect_s3_class (qry4, "overpass_query")
+    
+    qry5 <- add_osm_features (qry0,
+      features = list("amenity" = "restaurant", "amentity" = "pub")
+    )
+    expect_s3_class (qry5, "overpass_query")
 })

--- a/tests/testthat/test-set_bind_key_pre.R
+++ b/tests/testthat/test-set_bind_key_pre.R
@@ -1,0 +1,34 @@
+# NOTE: As of November 2022, these conditions are currently not possible, and
+# can only be triggered by direct calls to the internal functions. The bind
+# and key_pre parameters may be exposed in add_osm_features() in the future if
+# package developers decide the option could be useful.
+
+test_that ("set_bind_key_pre errors", {
+    features <- list ("amenity" = "restaurant", "amenity" = "pub")
+
+    expect_error (
+        set_bind_key_pre (
+            features = features,
+            bind = rep ("=", 3)
+        ),
+        "bind must be length 1 or the same length as features"
+    )
+
+    expect_error (
+        set_bind_key_pre (
+            features = features,
+            key_pre = rep ("", 3)
+        ),
+        "key_pre must be length 1 or the same length as features"
+    )
+
+    expect_error (
+        set_bind_key_pre (key_pre = "-"),
+        'key_pre must only include "" or "~"'
+    )
+
+    expect_error (
+        set_bind_key_pre (bind = "-"),
+        'bind must only include "=", "!=", "~", or "!~"'
+    )
+})


### PR DESCRIPTION
This pull request updates `add_osm_features()` per #277. I was initially trying to support the option of passing a custom key_pre and bind vector along with the named vector or list of features. To do this I created a helper function, set_bind_key_pre() to share handling of key_exact and value_exact w/ `add_osm_feature()`. Ultimately, I decided a less granular approach that supported the same key_exact and value_exact parameters as `add_osm_feature()` was sufficient but left the structure in place if needed in the future for more customizable queries. I also added several other utility functions that I thought helped make the code more readable but can incorporate back into the main functions if preferred.

I also included a small bug fix for `available_tags()`. Currently, if there is a red edit link on the OSM Wiki for a key, the returned list of tags includes an invalid tag, e.g. available_tags("building") returns the tag "library&action=edit&redlink=1". I added a line with a `gsub()` function to remove the ampersand and everything after.

Lastly, included one additional feature: adding the option to `opq_osm_id()` to pass id with a prefixed type, e.g. "relation/11158003". I've added a similar feature to a wrapper function I've built for osmdata because it is easy to copy the prefixed id out of an OSM url. Obviously, I can remove this change if it is unwanted.