### PR TITLE
fix(getbb): add check for NA values to close #280

### DIFF
--- a/R/getbb.R
+++ b/R/getbb.R
@@ -72,6 +72,11 @@ bbox_to_string <- function (bbox) {
             bbox <- c (y [1], x [1], y [2], x [2])
         }
     }
+  
+    if (any (is.na (bbox))) {
+      stop ("bbox contains 'NA' values")
+    }
+    
     return (paste0 (bbox, collapse = ","))
 }
 
@@ -176,7 +181,7 @@ getbb <- function (place_name,
         base_url,
         silent
     )
-
+    
     if (format_out == "data.frame") {
         return (obj)
     }
@@ -184,6 +189,11 @@ getbb <- function (place_name,
     bn <- as.numeric (obj$boundingbox [[1]])
     bb_mat <- matrix (c (bn [3:4], bn [1:2]), nrow = 2, byrow = TRUE)
     dimnames (bb_mat) <- list (c ("x", "y"), c ("min", "max"))
+    
+    if (any (is.na (bb_mat))) {
+      stop (paste0 ("`place_name` '", place_name ,"' can't be found"))
+    }
+    
     if (format_out == "matrix") {
         ret <- bb_mat
     } else if (format_out == "string") {

--- a/tests/testthat/test-getbb.R
+++ b/tests/testthat/test-getbb.R
@@ -58,6 +58,8 @@ test_that ("getbb-place_name", {
         }),
         "format_out not recognised"
     )
+    
+    expect_error (getbb ("Salzzburg"), "`place_name` 'Salzzburg' can't be found")
 })
 
 # Note that the polygon calls produce large mock files which are reduced with


### PR DESCRIPTION
- fix(getbb): add check for NA values w/ test
- fix(bbox_to_string): add check for NA values

Adding the check to bbox_to_string() alone didn't fix the issue since `getbb()` doesn't pass the results to `bbox_to_string()` if `format_out == "matrix"`. I used what I hope is a more informative error message for `getbb()`. The check for `bbox_to_string()` may be superfluous – `bbox_to_string(NA)` returns an error for non-numeric values – but I wanted to include it in this PR anyway since it was suggested as the approach.