### PR TITLE
Add the parameter `out` to `opq` to select the level of verbosity of the results

### DIFF
--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -582,7 +582,6 @@ getbb_sc <- function (x) {
 
 #' Return an OSM Overpass query as a \link{data.frame} object.
 #'
-# TODO: recommend queries with `out tags;` when implemented.
 #'
 #' @inheritParams osmdata_sp
 #' @param q An object of class `overpass_query` constructed with
@@ -592,6 +591,11 @@ getbb_sc <- function (x) {
 #' @param stringsAsFactors Should character strings in the 'data.frame' be
 #'      coerced to factors?
 #' @return A `data.frame` with id, type and tags of the the objects from the query.
+#'
+#' @details If you are not interested in the geometries of the results, it's a
+#'      good option to query for objects that match the features only and forget
+#'      about members of the ways and relations. You can achieve this by passing
+#'      the parameter `body = "tags"` to \code{\link{opq}}.
 #'
 #' @family extract
 #' @export

--- a/R/opq.R
+++ b/R/opq.R
@@ -105,7 +105,7 @@ opq <- function (bbox = NULL,  nodes_only = FALSE,
     if (has_geometry) {
         suffix <- paste0 (");\n(._;>;);\nout ", out, ";")
     } else {
-        suffix <- paste0 ("); out ", out, ";")
+        suffix <- paste0 ("); out", out, ";")
     }
 
     if (!missing (memsize)) {

--- a/R/opq.R
+++ b/R/opq.R
@@ -96,19 +96,15 @@ opq <- function (bbox = NULL,  nodes_only = FALSE,
     timeout <- format (timeout, scientific = FALSE)
     prefix <- paste0 ("[out:xml][timeout:", timeout, "]")
 
-    suffix <- ifelse (
-        nodes_only,
-        "); out;",
-        ");\n(._;>;);\nout body;"
-    ) # recurse down
     out <- try (match.arg (out))
     if (inherits (out, "try-error")) {
         stop ('out parameter must be "body", "tags", "meta", "skel", "tags center" or "ids".')
     }
-    has_geometry <- out %in% c ("body", "meta", "skel")
-    if (has_geometry && out != "body") {
-        suffix <- gsub ("out( body)*;", paste0 ("out ", out, ";"), suffix)
-    } else if (!has_geometry) {
+
+    has_geometry <- !nodes_only && out %in% c ("body", "meta", "skel")
+    if (has_geometry) {
+        suffix <- paste0 (");\n(._;>;);\nout ", out, ";")
+    } else {
         suffix <- paste0 ("); out ", out, ";")
     }
 

--- a/R/opq.R
+++ b/R/opq.R
@@ -101,9 +101,9 @@ opq <- function (bbox = NULL,  nodes_only = FALSE,
         "); out;",
         ");\n(._;>;);\nout body;"
     ) # recurse down
-    out <- match.arg (out)
-    if (is.na (out)) {
-        stop ('out must be "body", "tags", "meta", "skel", "tags center" or "id".')
+    out <- try (match.arg (out))
+    if (inherits (out, "try-error")) {
+        stop ('out parameter must be "body", "tags", "meta", "skel", "tags center" or "ids".')
     }
     has_geometry <- out %in% c ("body", "meta", "skel")
     if (has_geometry && out != "body") {

--- a/R/opq.R
+++ b/R/opq.R
@@ -109,7 +109,7 @@ opq <- function (bbox = NULL,  nodes_only = FALSE,
     if (has_geometry && out != "body") {
         suffix <- gsub ("out( body)*;", paste0 ("out ", out, ";"), suffix)
     } else if (!has_geometry) {
-        suffix <- gsub ("\\);(\\n\\(\\._;>;\\);\\n| )out( body)*;", paste0 ("); out ", out, ";"), suffix)
+        suffix <- paste0 ("); out ", out, ";")
     }
 
     if (!missing (memsize)) {

--- a/R/opq.R
+++ b/R/opq.R
@@ -18,6 +18,12 @@
 #'      relation, but this can be very inefficient for node-only queries.
 #'      Setting this value to `TRUE` for such cases makes queries more
 #'      efficient, with data returned in the `osm_points` list item.
+#' @param out The level of verbosity of the overpass result: `body` (geometries
+#'       and tags, the default), `tags` (tags without geometry), `meta` (like
+#'       body + Timestamp, Version, Changeset, User, User ID of the last edition),
+#'       `skel` (geometries only), `tags center` (tags without geometry + the
+#'       coordinates of the center of the bounding box) and `ids` (type and id of
+#'       the objects only).
 #' @param datetime If specified, a date and time to extract data from the OSM
 #'      database as it was up to the specified date and time, as described at
 #'      \url{https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#date}.
@@ -34,8 +40,14 @@
 #'
 #' @return An `overpass_query` object
 #'
+#' @details The `out` statement for `tags`, `tags center`and `id`, do not return
+#' geometries and `out = "meta"`is not yet implemented for all `osmdata_*`
+#' functions. Use [osmdata_xml] or [osmdata_data_frame] to get the result of
+#' these queries. For details, see the documentation of the
+#' [out statement](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#out).
+#'
 #' @note See
-#' /url{https://wiki.openstreetmap.org/wiki/Overpass_API#Resource_management_options_.28osm-script.29}
+#' \url{https://wiki.openstreetmap.org/wiki/Overpass_API#Resource_management_options_.28osm-script.29}
 #' for explanation of `timeout` and `memsize` (or `maxsize` in overpass terms).
 #' Note in particular the comment that queries with arbitrarily large `memsize`
 #' are likely to be rejected.
@@ -76,17 +88,30 @@
 #'     add_osm_feature (key = "place")
 #' opqa2 <- osmdata_sf (qa2)
 #' }
-opq <- function (bbox = NULL, nodes_only = FALSE,
+opq <- function (bbox = NULL,  nodes_only = FALSE,
+                 out = c ("body", "tags", "meta", "skel", "tags center", "ids"),
                  datetime = NULL, datetime2 = NULL,
                  timeout = 25, memsize) {
 
     timeout <- format (timeout, scientific = FALSE)
     prefix <- paste0 ("[out:xml][timeout:", timeout, "]")
+
     suffix <- ifelse (
         nodes_only,
         "); out;",
         ");\n(._;>;);\nout body;"
     ) # recurse down
+    out <- match.arg (out)
+    if (is.na (out)) {
+        stop ('out must be "body", "tags", "meta", "skel", "tags center" or "id".')
+    }
+    has_geometry <- out %in% c ("body", "meta", "skel")
+    if (has_geometry && out != "body") {
+        suffix <- gsub ("out( body)*;", paste0 ("out ", out, ";"), suffix)
+    } else if (!has_geometry) {
+        suffix <- gsub ("\\);(\\n\\(\\._;>;\\);\\n| )out( body)*;", paste0 ("); out ", out, ";"), suffix)
+    }
+
     if (!missing (memsize)) {
         prefix <- paste0 (
             prefix, "[maxsize:", # nocov

--- a/man/opq.Rd
+++ b/man/opq.Rd
@@ -7,6 +7,7 @@
 opq(
   bbox = NULL,
   nodes_only = FALSE,
+  out = c("body", "tags", "meta", "skel", "tags center", "ids"),
   datetime = NULL,
   datetime2 = NULL,
   timeout = 25,
@@ -34,6 +35,13 @@ relation, but this can be very inefficient for node-only queries.
 Setting this value to \code{TRUE} for such cases makes queries more
 efficient, with data returned in the \code{osm_points} list item.}
 
+\item{out}{The level of verbosity of the overpass result: \code{body} (geometries
+and tags, the default), \code{tags} (tags without geometry), \code{meta} (like
+body + Timestamp, Version, Changeset, User, User ID of the last edition),
+\code{skel} (geometries only), \verb{tags center} (tags without geometry + the
+coordinates of the center of the bounding box) and \code{ids} (type and id of
+the objects only).}
+
 \item{datetime}{If specified, a date and time to extract data from the OSM
 database as it was up to the specified date and time, as described at
 \url{https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#date}.
@@ -57,9 +65,16 @@ An \code{overpass_query} object
 \description{
 Build an Overpass query
 }
+\details{
+The \code{out} statement for \code{tags}, \verb{tags center}and \code{id}, do not return
+geometries and \code{out = "meta"}is not yet implemented for all \verb{osmdata_*}
+functions. Use \link{osmdata_xml} or \link{osmdata_data_frame} to get the result of
+these queries. For details, see the documentation of the
+\href{https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#out}{out statement}.
+}
 \note{
 See
-/url{https://wiki.openstreetmap.org/wiki/Overpass_API#Resource_management_options_.28osm-script.29}
+\url{https://wiki.openstreetmap.org/wiki/Overpass_API#Resource_management_options_.28osm-script.29}
 for explanation of \code{timeout} and \code{memsize} (or \code{maxsize} in overpass terms).
 Note in particular the comment that queries with arbitrarily large \code{memsize}
 are likely to be rejected.

--- a/man/osmdata_data_frame.Rd
+++ b/man/osmdata_data_frame.Rd
@@ -28,6 +28,12 @@ A \code{data.frame} with id, type and tags of the the objects from the query.
 \description{
 Return an OSM Overpass query as a \link{data.frame} object.
 }
+\details{
+If you are not interested in the geometries of the results, it's a
+good option to query for objects that match the features only and forget
+about members of the ways and relations. You can achieve this by passing
+the parameter \code{body = "tags"} to \code{\link{opq}}.
+}
 \examples{
 \dontrun{
 hampi_df <- opq ("hampi india") \%>\%

--- a/tests/testthat/test-data_frame-osm.R
+++ b/tests/testthat/test-data_frame-osm.R
@@ -180,13 +180,11 @@ test_that ("date", {
 
 test_that ("out meta & diff", {
     q <- getbb ("Conflent", featuretype = "relation") %>%
-        opq (nodes_only = TRUE, datetime = "2020-11-07T00:00:00Z",
+        opq (nodes_only = TRUE, out = "meta", datetime = "2020-11-07T00:00:00Z",
              datetime2 = "2022-12-04T00:00:00Z") %>%
         add_osm_feature ("natural", "peak") %>%
         add_osm_feature ("prominence")  %>%
         add_osm_feature ("name:ca")
-
-    q$suffix <- ");\n(._;>;);\nout meta;"
 
     osm_meta_diff <- test_path ("fixtures", "osm-meta_diff.osm")
     doc <- xml2::read_xml (osm_meta_diff)
@@ -218,13 +216,12 @@ test_that ("out meta & diff", {
 
 test_that ("out meta & adiff", {
     q <- getbb ("Conflent", featuretype = "relation") %>%
-        opq (nodes_only = TRUE, datetime = "2020-11-07T00:00:00Z") %>%
+        opq (nodes_only = TRUE, out = "meta", datetime = "2020-11-07T00:00:00Z") %>%
         add_osm_feature ("natural", "peak") %>%
         add_osm_feature ("prominence")  %>%
         add_osm_feature ("name:ca")
 
     q$prefix <- gsub ("date:", "adiff:", q$prefix)
-    q$suffix <- ");\n(._;>;);\nout meta;"
 
     osm_meta_adiff <- test_path ("fixtures", "osm-meta_adiff.osm")
     doc <- xml2::read_xml (osm_meta_adiff)

--- a/tests/testthat/test-opq.R
+++ b/tests/testthat/test-opq.R
@@ -56,7 +56,7 @@ test_that ("out", {
             bbox = c (-0.118, 51.514, -0.115, 51.517),
             out = "blah"
         ),
-        "'arg' should be one of "
+        'out parameter must be "body", "tags", "meta", "skel", "tags center" or "ids".'
     )
 
     q_geo <- lapply (c ("meta", "skel"), function (x) {
@@ -87,7 +87,7 @@ test_that ("out", {
             bbox = c (-0.118, 51.514, -0.115, 51.517),
             out = "blah"
         ),
-        "'arg' should be one of "
+        'out parameter must be "body", "tags", "meta", "skel", "tags center" or "ids".'
     )
 
     q_geo <- lapply (c ("meta", "skel"), function (x) {

--- a/tests/testthat/test-opq.R
+++ b/tests/testthat/test-opq.R
@@ -163,7 +163,7 @@ test_that ("opq_string", {
     )
     s1 <- opq_string (q1)
     # nodes only, so "out" instead of "out body" and no way nor relation
-    expect_false (grepl ("out body", s1))
+    expect_false (grepl ("\\(\\._;>;\\)", s1))
     expect_false (grepl ("way|relation", s1))
 
     q1 <- opq (
@@ -172,7 +172,7 @@ test_that ("opq_string", {
     )
     s1 <- opq_string (q1)
     # nodes only, so "out" instead of "out body" and no way nor relation on clauses
-    expect_false (grepl ("out body", s1))
+    expect_false (grepl ("\\(\\._;>;\\)", s1))
     expect_false (all (grepl ("way|relation", strsplit(s1, "\\n")[[1]][-2])))
 
     # nodes_only parameter with features:
@@ -183,7 +183,7 @@ test_that ("opq_string", {
     q1 <- add_osm_feature(q1, key = "amenity", value = "restaurant")
     s1 <- opq_string (q1)
     # nodes only, so "out" instead of "out body" and no way nor relation
-    expect_false (grepl ("out body", s1))
+    expect_false (grepl ("\\(\\._;>;\\)", s1))
     expect_false (grepl ("way|relation", s1))
 
     q1 <- opq (
@@ -193,7 +193,7 @@ test_that ("opq_string", {
     q1 <- add_osm_feature(q1, key = "amenity", value = "restaurant")
     s1 <- opq_string (q1)
     # nodes only, so "out" instead of "out body" and no way nor relation on clauses
-    expect_false (grepl ("out body", s1))
+    expect_false (grepl ("\\(\\._;>;\\)", s1))
     expect_false (all (grepl ("way|relation", strsplit(s1, "\\n")[[1]][-2])))
 
     # key-value pair:
@@ -332,3 +332,4 @@ test_that ("opq_around", {
     expect_true (grepl ("key", x_key_val))
     expect_true (grepl ("val", x_key_val))
 })
+

--- a/tests/testthat/test-opq.R
+++ b/tests/testthat/test-opq.R
@@ -48,6 +48,72 @@ test_that ("datetime", {
     expect_true (grepl ("diff\\:", q2$prefix))
 })
 
+test_that ("out", {
+
+    q0 <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517))
+    expect_error (
+        opq (
+            bbox = c (-0.118, 51.514, -0.115, 51.517),
+            out = "blah"
+        ),
+        "'arg' should be one of "
+    )
+
+    q_geo <- lapply (c ("meta", "skel"), function (x) {
+        q<- opq (bbox = c (-0.118, 51.514, -0.115, 51.517), out = x)
+        expect_true (!identical (q0, q))
+        expect_identical (names (q0), names (q))
+        expect_identical (
+            q0 [names (q0) != "suffix"],
+            q [names (q) != "suffix"]
+        )
+        expect_true (grepl ("^\\);\\n\\(\\._;>;\\);\\nout[a-z ]+;$", q$suffix))
+    })
+    q_no_geo <- lapply (c ("tags", "tags center", "ids"), function (x) {
+        q <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517), out = x)
+        expect_true (!identical (q0, q))
+        expect_identical (names (q0), names (q))
+        expect_identical (
+            q0 [names (q0) != "suffix"],
+            q0 [names (q) != "suffix"]
+        )
+        expect_true (grepl ("^\\); out[a-z ]+;$", q$suffix))
+    })
+
+    # nodes_only
+    q1 <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517), nodes_only = TRUE)
+    expect_error (
+        opq (
+            bbox = c (-0.118, 51.514, -0.115, 51.517),
+            out = "blah"
+        ),
+        "'arg' should be one of "
+    )
+
+    q_geo <- lapply (c ("meta", "skel"), function (x) {
+        q<- opq (bbox = c (-0.118, 51.514, -0.115, 51.517),
+                 nodes_only = TRUE, out = x)
+        expect_true (!identical (q1, q))
+        expect_identical (names (q1), names (q))
+        expect_identical (
+            q1 [names (q1) != "suffix"],
+            q1 [names (q) != "suffix"]
+        )
+        expect_true (grepl ("^\\); out[a-z ]+;$", q$suffix))
+    })
+    q_no_geo <- lapply (c ("tags", "tags center", "ids"), function (x) {
+        q <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517),
+                  nodes_only = TRUE, out = x)
+        expect_true (!identical (q1, q))
+        expect_identical (names (q1), names (q))
+        expect_identical (
+            q1 [names (q1) != "suffix"],
+            q1 [names (q) != "suffix"]
+        )
+        expect_true (grepl ("^\\); out[a-z ]+;$", q$suffix))
+    })
+})
+
 test_that ("opq_string", {
 
     # bbox only:


### PR DESCRIPTION
I can replicate the option for `opq_osm_id`, `opq_enclosing` and `opq_around`