### PR TITLE
Fix the logic of parameter checks for osmdata_*(doc = doc)

### DIFF
--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -86,8 +86,8 @@ osmdata_xml <- function (q, filename, quiet = TRUE, encoding) {
         encoding <- "UTF-8"
     }
 
-    if (missing (q) & !quiet) {
-        message ("q missing: osmdata object will not include query")
+    if (missing (q)) {
+        stop ('argument "q" is missing, with no default.')
     } else if (is (q, "overpass_query")) {
         q <- opq_string_intern (q, quiet = quiet)
     } else if (!is.character (q)) {
@@ -130,8 +130,14 @@ osmdata_xml <- function (q, filename, quiet = TRUE, encoding) {
 osmdata_sp <- function (q, doc, quiet = TRUE) {
 
     obj <- osmdata () # uses class def
-    if (missing (q) & !quiet) {
-        message ("q missing: osmdata object will not include query")
+    if (missing (q)) {
+        if (missing (doc)) {
+            stop ('arguments "q" and "doc" are missing, with no default. ',
+                  "At least one must be provided.")
+        }
+        if (!quiet) {
+            message ("q missing: osmdata object will not include query")
+        }
     } else if (is (q, "overpass_query")) {
         obj$bbox <- q$bbox
         obj$overpass_call <- opq_string_intern (q, quiet = quiet)
@@ -387,6 +393,10 @@ osmdata_sf <- function (q, doc, quiet = TRUE, stringsAsFactors = FALSE) { # noli
     obj <- osmdata () # uses class def
 
     if (missing (q)) {
+        if (missing (doc)) {
+            stop ('arguments "q" and "doc" are missing, with no default. ',
+                  "At least one must be provided.")
+        }
         if (!quiet) {
             message ("q missing: osmdata object will not include query")
         }
@@ -512,8 +522,14 @@ osmdata_sc <- function (q, doc, quiet = TRUE) {
 
     obj <- osmdata () # class def used here to for fill_overpass_data fn
 
-    if (missing (q) & !quiet) {
-        message ("q missing: osmdata object will not include query")
+    if (missing (q)) {
+        if (missing (doc)) {
+            stop ('arguments "q" and "doc" are missing, with no default. ',
+                  "At least one must be provided.")
+        }
+        if (!quiet) {
+            message ("q missing: osmdata object will not include query")
+        }
     } else if (is (q, "overpass_query")) {
         obj$bbox <- q$bbox
         obj$overpass_call <- opq_string_intern (q, quiet = quiet)
@@ -819,3 +835,4 @@ rbind_add_columns <- function (..., deparse.level = 0, make.row.names = FALSE,
 
     return (res)
 }
+

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -119,23 +119,37 @@ test_that ("osmdata without query", {
     osm_multi <- test_path ("fixtures", "osm-multi.osm")
     doc <- xml2::read_xml (osm_multi)
 
+    expect_silent ( x_sp <- osmdata_sp (doc = doc))
+    expect_silent ( x_sf <- osmdata_sf (doc = doc))
+    # expect_silent ( x_sc <- osmdata_sc (doc = doc)) # fails without bbox
     expect_silent ( x_df <- osmdata_data_frame (doc = doc))
+
+    expect_s3_class ( x_sp, "osmdata")
+    expect_s3_class ( x_sf, "osmdata")
+    # expect_s3_class ( x_sc, "osmdata") # fails without bbox
     expect_s3_class ( x_df, "data.frame")
 
+    expect_message (
+        x_sp <- osmdata_sp (doc = doc, quiet = FALSE),
+        "q missing: osmdata object will not include query"
+    )
+    expect_message (
+        x_sf <- osmdata_sf (doc = doc, quiet = FALSE),
+        "q missing: osmdata object will not include query"
+    )
+    # expect_message (
+    #      x_sc <- osmdata_sc (doc = doc, quiet = FALSE), # fails without bbox
+    #     "q missing: osmdata object will not include query"
+    # )
     expect_message (
          x_df <- osmdata_data_frame (doc = doc, quiet = FALSE),
         "q missing: osmdata object will not include query"
     )
+
+    expect_s3_class ( x_sp, "osmdata")
+    expect_s3_class ( x_sf, "osmdata")
+    # expect_s3_class ( x_sc, "osmdata") # fails without bbox
     expect_s3_class ( x_df, "data.frame")
-})
-
-test_that ("osmdata without query", {
-    osm_multi <- test_path ("fixtures", "osm-multi.osm")
-    doc <- xml2::read_xml (osm_multi)
-
-    expect_s3_class ( osmdata_sp (doc = doc), "osmdata")
-    expect_s3_class ( osmdata_sf (doc = doc), "osmdata")
-    # expect_s3_class ( osmdata_sc (doc = doc), "osmdata")
 })
 
 test_that ("make_query", {

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -78,15 +78,15 @@ test_that ("query_errors", {
     )
     expect_error (
         osmdata_sp (),
-        "argument \"q\" is missing, with no default"
+        'arguments "q" and "doc" are missing, with no default. '
     )
     expect_error (
         osmdata_sf (),
-        "query must be a single character string"
+        'arguments "q" and "doc" are missing, with no default. '
     )
     expect_error (
         osmdata_sc (),
-        "argument \"q\" is missing, with no default"
+        'arguments "q" and "doc" are missing, with no default. '
     )
     expect_error (
         osmdata_data_frame (),
@@ -127,6 +127,15 @@ test_that ("osmdata without query", {
         "q missing: osmdata object will not include query"
     )
     expect_s3_class ( x_df, "data.frame")
+})
+
+test_that ("osmdata without query", {
+    osm_multi <- test_path ("fixtures", "osm-multi.osm")
+    doc <- xml2::read_xml (osm_multi)
+
+    expect_s3_class ( osmdata_sp (doc = doc), "osmdata")
+    expect_s3_class ( osmdata_sf (doc = doc), "osmdata")
+    # expect_s3_class ( osmdata_sc (doc = doc), "osmdata")
 })
 
 test_that ("make_query", {


### PR DESCRIPTION
Now the code match the documentation and works for calls with `doc` and no `q` parameter.
TODO: `osmdata_sc` fails because it requires the bbox