### PR TITLE
Optimize osmdata data frame

### DIFF
--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -758,164 +758,67 @@ xml_adiff_to_df <- function (doc,
         ))
     }
 
-    action_type <- xml2::xml_attr (osm_actions, attr = "type")
+    osm_obj <- xml2::xml_find_all (osm_actions, ".//node|.//way|.//relation")
 
-    df_l <- mapply (function (action, type) {
-        osm_obj <- xml2::xml_find_all (action, ".//node|.//way|.//relation")
-        osm_type <- xml2::xml_name (osm_obj)
-        osm_id <- xml2::xml_attr (osm_obj, attr = "id")
+    tagsU <- xml2::xml_find_all (osm_actions, xpath = ".//tag")
+    col_names <- sort (unique (xml2::xml_attr (tagsU, attr="k")))
+    m <- matrix (nrow = length (osm_obj), ncol = length (col_names),
+                 dimnames = list (NULL, col_names))
 
-        if (type == "modify") {
+    tags <- xml2::xml_find_all (osm_obj, xpath = ".//tag", flatten = FALSE)
+    has_tags <- which (vapply (tags, length, FUN.VALUE = integer (1)) > 0)
+    for (i in has_tags) {
+        tag <- xml2::xml_attrs (tags[[i]])
+        tagV <- vapply (tag, function (x) x, FUN.VALUE = character (2))
+        m[i, tagV[1, ]] <- tagV[2, ]
+    }
 
-            dates <- c (datetime_from, datetime_to)
-            tags <- xml2::xml_find_all (
-                osm_obj,
-                xpath = ".//tag",
-                flatten = FALSE
-            )
-            tags_l <- mapply (function (x, adiff_date) {
-                tag <- xml2::xml_attrs (x)
-                tag <- structure (lapply (tag, function (y) y [["v"]]),
-                    names = vapply (tag, function (y) y ["k"], character (1))
-                )
-                list2DF (c (list (
-                    adiff_action = "modify",
-                    adiff_date = adiff_date
-                ), tag), nrow = 1)
-            }, x = tags, adiff_date = dates, SIMPLIFY = FALSE)
-            df <- do.call (
-                rbind_add_columns,
-                c (tags_l, list (stringsAsFactors = stringsAsFactors))
-            )
+    osm_type <- xml2::xml_name(osm_obj)
+    osm_id <- xml2::xml_attr(osm_obj, "id")
 
-        } else if (type == "delete") {
-
-            dates <- c (datetime_from, datetime_to)
-            osm_visible <- xml2::xml_attr (osm_obj, attr = "visible")
-            tags <- xml2::xml_find_all (
-                osm_obj,
-                xpath = ".//tag",
-                flatten = FALSE
-            )
-            tags_l <- mapply (
-                function (x, adiff_date, adiff_visible) {
-                    tag <- xml2::xml_attrs (x)
-                    if (length (tag) == 0) {
-                        return (list2DF (
-                            list (
-                                adiff_action = "delete",
-                                adiff_date = adiff_date,
-                                adiff_visible = adiff_visible
-                            ),
-                            nrow = 1
-                        ))
-                    }
-                    tag <- structure (lapply (tag, function (y) y [["v"]]),
-                        names = vapply (tag, function (y) y ["k"], character (1))
-                    )
-                    list2DF (c (list (
-                        adiff_action = "delete", adiff_date = adiff_date,
-                        adiff_visible = adiff_visible
-                    ), tag), nrow = 1)
-                },
-                x = tags,
-                adiff_date = dates,
-                adiff_visible = osm_visible,
-                SIMPLIFY = FALSE
-            )
-            df <- do.call (
-                rbind_add_columns,
-                c (tags_l, list (stringsAsFactors = stringsAsFactors))
-            )
-
-        } else if (type == "create") {
-
-            tags <- xml2::xml_find_all (
-                osm_obj,
-                xpath = ".//tag",
-                flatten = TRUE
-            )
-            tag <- xml2::xml_attrs (tags)
-            tag <- structure (lapply (tag, function (y) y [["v"]]),
-                names = vapply (tag, function (y) y ["k"], character (1))
-            )
-            df <- list2DF (c (list (
-                adiff_action = "create",
-                adiff_date = datetime_to
-            ), tag), nrow = 1)
-
+    action_type <- xml2::xml_attr (osm_actions, "type")
+    adiff_action <- lapply(action_type, function (x) {
+        if (x != "create") {
+            x <- rep (x, 2)
         }
+        x
+    })
+    adiff_action <- do.call (c, adiff_action)
 
-        meta <- all (xml2::xml_has_attr (
-            xml2::xml_find_all (osm_actions, ".//node|.//way|.//relation"),
-            c ("version", "timestamp", "changeset", "uid", "user")
-        ))
-        if (meta) {
-            osm_version <- xml2::xml_attr (osm_obj, attr = "version")
-            osm_timestamp <- xml2::xml_attr (osm_obj, attr = "timestamp")
-            osm_changeset <- xml2::xml_attr (osm_obj, attr = "changeset")
-            osm_uid <- xml2::xml_attr (osm_obj, attr = "uid")
-            osm_user <- xml2::xml_attr (osm_obj, attr = "user")
-
-            df <- data.frame (osm_type, osm_id, osm_version, osm_timestamp,
-                osm_changeset, osm_uid, osm_user, df,
-                stringsAsFactors = stringsAsFactors, check.names = FALSE
-            )
+    adiff_date <- lapply(action_type, function (x) {
+        if (x == "create") {
+            x <- datetime_to
         } else {
-            df <- data.frame (osm_id, osm_type, df,
-                stringsAsFactors = stringsAsFactors, check.names = FALSE
-            )
+            x <- c (datetime_from, datetime_to)
         }
+        x
+    })
+    adiff_date <- do.call (c, adiff_date)
 
-        return (df)
-    }, action = osm_actions, type = action_type)
+    adiff_visible <- xml2::xml_attr(osm_obj, "visible")
+    sel_FALSE <- which (adiff_visible == "false")
+    sel_TRUE <- which (adiff_visible == "true")
+    adiff_visible[sel_FALSE]<- FALSE
+    adiff_visible[sel_TRUE]<- TRUE
 
-    df <- do.call (
-        rbind_add_columns,
-        c (df_l, list (stringsAsFactors = stringsAsFactors))
-    )
+    if (all (xml2::xml_has_attr (osm_obj,
+                                 c ("version", "timestamp", "changeset", "uid", "user")))) {
 
-    df$adiff_visible <- NA
-    df$adiff_visible [which (df$adiff_visible == "false")] <- FALSE
-    df$adiff_visible [which (df$adiff_visible == "true")] <- TRUE
+        osm_version <- xml2::xml_attr (osm_obj, attr = "version")
+        osm_timestamp <- xml2::xml_attr (osm_obj, attr = "timestamp")
+        osm_changeset <- xml2::xml_attr (osm_obj, attr = "changeset")
+        osm_uid <- xml2::xml_attr (osm_obj, attr = "uid")
+        osm_user <- xml2::xml_attr (osm_obj, attr = "user")
 
-    ord_cols <- intersect (
-        c (
-            "osm_type", "osm_id", "osm_version", "osm_timestamp",
-            "osm_changeset", "osm_uid", "osm_user",
-            "adiff_action", "adiff_date", "adiff_visible"
-        ),
-        names (df)
-    )
+        df <- data.frame (osm_type, osm_id, osm_version, osm_timestamp,
+                          osm_changeset, osm_uid, osm_user,
+                          adiff_action, adiff_date, adiff_visible, m,
+                          stringsAsFactors = stringsAsFactors, check.names = FALSE)
 
-    ord_cols <- c (ord_cols, setdiff (sort (names (df)), ord_cols))
-    df <- df [, ord_cols]
+    } else {
+        df <- data.frame(osm_type, osm_id, adiff_action, adiff_date, adiff_visible, m,
+                         stringsAsFactors = stringsAsFactors, check.names = FALSE)
+    }
 
     return (df)
-}
-
-rbind_add_columns <- function (..., deparse.level = 0, make.row.names = FALSE,
-                               stringsAsFactors = FALSE) {
-
-    input <- list (...)
-    col_names <- unique (unlist (lapply (input, names)))
-
-    res <- lapply (input, function (x) {
-        mis_cols <- setdiff (col_names, names (x))
-        mis_cols <- structure (as.list (rep (
-            list (rep (NA, nrow (x))),
-            length (mis_cols)
-        )), names = mis_cols)
-        out <- list2DF (c (x, mis_cols))
-        out <- out [, col_names]
-    })
-
-    res <- c (res, list (
-        deparse.level = deparse.level,
-        make.row.names = make.row.names,
-        stringsAsFactors = stringsAsFactors
-    ))
-    res <- do.call (rbind, res)
-
-    return (res)
 }

--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -704,15 +704,16 @@ xml_to_df <- function (doc, stringsAsFactors = FALSE) {
     }
 
     tags <- xml2::xml_find_all (osm_obj, xpath = ".//tag", flatten = FALSE)
-    tagsU <- xml2::xml_find_all (osm_obj, xpath = ".//tag")
-    col_names <- sort (unique (xml2::xml_attr (tagsU, attr="k")))
+    tags_u <- xml2::xml_find_all (osm_obj, xpath = ".//tag")
+    col_names <- sort (unique (xml2::xml_attr (tags_u, attr = "k")))
     m <- matrix (nrow = length (tags), ncol = length (col_names),
-                 dimnames = list (NULL, col_names))
+                 dimnames = list (NULL, col_names)
+    )
     has_tags <- which (vapply (tags, length, FUN.VALUE = integer (1)) > 0)
     for (i in has_tags) {
-        tag <- xml2::xml_attrs (tags[[i]])
+        tag <- xml2::xml_attrs (tags [[i]])
         tagV <- vapply (tag, function (x) x, FUN.VALUE = character (2))
-        m[i, tagV[1, ]] <- tagV[2, ]
+        m [i, tagV [1, ]] <- tagV [2, ]
     }
 
     osm_type <- xml2::xml_name (osm_obj)
@@ -754,30 +755,33 @@ xml_adiff_to_df <- function (doc,
     if (length (osm_actions) == 0) {
         return (data.frame (
             osm_type = character (), osm_id = character (),
+            adiff_action = character (), adiff_date = character (),
+            adiff_visible = character (),
             stringsAsFactors = stringsAsFactors
         ))
     }
 
     osm_obj <- xml2::xml_find_all (osm_actions, ".//node|.//way|.//relation")
 
-    tagsU <- xml2::xml_find_all (osm_actions, xpath = ".//tag")
-    col_names <- sort (unique (xml2::xml_attr (tagsU, attr="k")))
+    tags_u <- xml2::xml_find_all (osm_actions, xpath = ".//tag")
+    col_names <- sort (unique (xml2::xml_attr (tags_u, attr = "k")))
     m <- matrix (nrow = length (osm_obj), ncol = length (col_names),
-                 dimnames = list (NULL, col_names))
+                 dimnames = list (NULL, col_names)
+    )
 
     tags <- xml2::xml_find_all (osm_obj, xpath = ".//tag", flatten = FALSE)
     has_tags <- which (vapply (tags, length, FUN.VALUE = integer (1)) > 0)
     for (i in has_tags) {
-        tag <- xml2::xml_attrs (tags[[i]])
+        tag <- xml2::xml_attrs (tags [[i]])
         tagV <- vapply (tag, function (x) x, FUN.VALUE = character (2))
-        m[i, tagV[1, ]] <- tagV[2, ]
+        m [i, tagV [1, ]] <- tagV [2, ]
     }
 
-    osm_type <- xml2::xml_name(osm_obj)
-    osm_id <- xml2::xml_attr(osm_obj, "id")
+    osm_type <- xml2::xml_name (osm_obj)
+    osm_id <- xml2::xml_attr (osm_obj, "id")
 
     action_type <- xml2::xml_attr (osm_actions, "type")
-    adiff_action <- lapply(action_type, function (x) {
+    adiff_action <- lapply (action_type, function (x) {
         if (x != "create") {
             x <- rep (x, 2)
         }
@@ -785,7 +789,7 @@ xml_adiff_to_df <- function (doc,
     })
     adiff_action <- do.call (c, adiff_action)
 
-    adiff_date <- lapply(action_type, function (x) {
+    adiff_date <- lapply (action_type, function (x) {
         if (x == "create") {
             x <- datetime_to
         } else {
@@ -795,14 +799,15 @@ xml_adiff_to_df <- function (doc,
     })
     adiff_date <- do.call (c, adiff_date)
 
-    adiff_visible <- xml2::xml_attr(osm_obj, "visible")
-    sel_FALSE <- which (adiff_visible == "false")
-    sel_TRUE <- which (adiff_visible == "true")
-    adiff_visible[sel_FALSE]<- FALSE
-    adiff_visible[sel_TRUE]<- TRUE
+    adiff_visible <- xml2::xml_attr (osm_obj, "visible")
+    adiff_visible [which (adiff_visible == "false")] <- FALSE
+    adiff_visible [which (adiff_visible == "true")] <- TRUE
 
-    if (all (xml2::xml_has_attr (osm_obj,
-                                 c ("version", "timestamp", "changeset", "uid", "user")))) {
+    if (all (xml2::xml_has_attr (
+            osm_obj,
+            c ("version", "timestamp", "changeset", "uid", "user"))
+        )
+    ) {
 
         osm_version <- xml2::xml_attr (osm_obj, attr = "version")
         osm_timestamp <- xml2::xml_attr (osm_obj, attr = "timestamp")
@@ -811,13 +816,16 @@ xml_adiff_to_df <- function (doc,
         osm_user <- xml2::xml_attr (osm_obj, attr = "user")
 
         df <- data.frame (osm_type, osm_id, osm_version, osm_timestamp,
-                          osm_changeset, osm_uid, osm_user,
-                          adiff_action, adiff_date, adiff_visible, m,
-                          stringsAsFactors = stringsAsFactors, check.names = FALSE)
+            osm_changeset, osm_uid, osm_user,
+            adiff_action, adiff_date, adiff_visible, m,
+            stringsAsFactors = stringsAsFactors, check.names = FALSE
+        )
 
     } else {
-        df <- data.frame(osm_type, osm_id, adiff_action, adiff_date, adiff_visible, m,
-                         stringsAsFactors = stringsAsFactors, check.names = FALSE)
+        df <- data.frame(osm_type, osm_id,
+            adiff_action, adiff_date, adiff_visible, m,
+            stringsAsFactors = stringsAsFactors, check.names = FALSE
+        )
     }
 
     return (df)

--- a/tests/testthat/test-data_frame-osm.R
+++ b/tests/testthat/test-data_frame-osm.R
@@ -104,7 +104,7 @@ test_that ("empty result", {
 
     x <- osmdata_data_frame (q0, doc)
 
-    cols <- c ("osm_type", "osm_id")
+    cols <- c ("osm_type", "osm_id", "adiff_action", "adiff_date", "adiff_visible")
     expect_named (x, cols)
     expect_s3_class (x, "data.frame")
     expect_identical (nrow (x), 0L)


### PR DESCRIPTION
Preallocate tag columns in a matrix and use xml2 to extract the values for all the nodes in one call for each column.


``` r
library(xml2)
library(osmdata)
#> Data (c) OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright
# devtools::load_all (".")
q0 <- opq (bbox = c(-0.27, 51.47, -0.20, 51.50))
q1 <- add_osm_feature (q0, key = "name", value = "River Thames")

doc <- osmdata_xml (q1, filename = test_path ("export.osm"))
doc <- xml2::read_xml ( test_path ("export.osm"))
stringsAsFactors <- FALSE
osm_obj <- xml2::xml_find_all (doc, ".//node|.//way|.//relation")

mb <- list()

## Implementations of the critical code ----
impl <- list()
impl$baseline <- function(osm_obj=osm_obj) {
    tags <- xml2::xml_find_all (osm_obj, xpath = ".//tag", flatten = FALSE)
    tagsL <- lapply (tags, function(x) {
        tag <- xml2::xml_attrs (x)
        tag <- structure (lapply (tag, function(y) y[["v"]]),
                          names = vapply(tag, function(y) y["k"], character(1)))
        list2DF (tag, nrow = 1)
    })
    df <- do.call(osmdata:::rbind_add_columns, c (tagsL, list (stringsAsFactors = stringsAsFactors)))
    return (df[, sort(names(df))])
}

impl$preallocate <- function(osm_obj=osm_obj) {
    tags <- xml2::xml_find_all (osm_obj, xpath = ".//tag", flatten = FALSE)
    tagsU <- xml2::xml_find_all (osm_obj, xpath = ".//tag")
    col_names <- sort(unique(xml2::xml_attr(tagsU, attr="k")))
    m <- matrix(nrow = length (tags), ncol = length (col_names), dimnames = list(NULL, col_names))
    for (i in seq_along(tags)) {
        tag <- xml2::xml_attrs (tags[[i]])
        cols <- vapply (tag, function(x) x["k"], FUN.VALUE = character(1))
        m[i, cols] <- vapply (tag, function(x) x["v"], FUN.VALUE = character(1))
    }
    return (as.data.frame(m, stringsAsFactors = stringsAsFactors))
}

impl$preallocate_sel <- function(osm_obj=osm_obj) {
    tags <- xml2::xml_find_all (osm_obj, xpath = ".//tag", flatten = FALSE)
    tagsU <- xml2::xml_find_all (osm_obj, xpath = ".//tag")
    col_names <- sort(unique(xml2::xml_attr(tagsU, attr="k")))
    m <- matrix(nrow = length (tags), ncol = length (col_names), dimnames = list(NULL, col_names))
    has_tags <- which (vapply(tags, length, FUN.VALUE = integer(1)) > 0)
    for (i in has_tags) {
        tag <- xml2::xml_attrs (tags[[i]])
        tagV <- vapply (tag, function(x) x, FUN.VALUE = character(2))
        m[i, tagV[1, ]] <- tagV[2, ]
    }
    return (as.data.frame(m, stringsAsFactors = stringsAsFactors))
}

impl <- lapply(impl, compiler::cmpfun)


## Benchmark ----
mb <- microbenchmark::microbenchmark(impl$baseline(osm_obj=osm_obj),
                                     impl$preallocate(osm_obj=osm_obj),
                                     impl$preallocate_sel(osm_obj=osm_obj),
                                     times = 20, check = "equal")
ggplot2::autoplot(mb)
```

![](https://i.imgur.com/r3DzQTV.png)<!-- -->

``` r
mb
#> Unit: milliseconds
#>                                     expr       min        lq      mean
#>         impl$baseline(osm_obj = osm_obj) 6260.8424 6382.3150 6776.0929
#>      impl$preallocate(osm_obj = osm_obj)  367.2648  391.6788  434.5904
#>  impl$preallocate_sel(osm_obj = osm_obj)  255.9076  277.8087  308.8099
#>     median        uq       max neval cld
#>  6576.6413 6980.1697 8472.3096    20   b
#>   414.1598  462.8838  642.2182    20  a 
#>   299.4965  321.3393  458.2554    20  a
```

The new implementation is based on the `preallocate_sel` code. The benchmark shows that is up to 20 times faster than the current implementation.