### PR TITLE
Fix key modifications for non-valid column names in osmdata_* functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: osmdata
 Title: Import 'OpenStreetMap' Data as Simple Features or Spatial Objects
-Version: 0.1.10.026
+Version: 0.1.10.027
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre")),
     person("Bob", "Rudis", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 - `opq()` can now utilise overpass ability to filter results by area; thanks to @jmaspons (#286).
 - `opq()` now has additional "out" parameter to control the kinds of data returned by overpass; thanks to @jmaspons (#288).
 - `opq()` now has additional "osm_types" parameter to provide finer control of which kinds of data are returned by overpass; thanks to @jmaspons (#295).
+- `sp` dependency moved to suggested and added missing osmdata_* functions to docs; by @jmaspons & @mpadge (#302)
+- Fix key modifications for non-valid column names and handle duplicated column names in `osmdata_*` functions; by @jmaspons (#303)
 - @elipousson is new package contributor, thanks to the above work.
 - @jmaspons is new package author, thanks to #285.
 

--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -846,7 +846,7 @@ xml_to_df <- function (doc, stringsAsFactors = FALSE) {
             "renamed by appending `.n`:\n\t",
             paste (setdiff (cols_no_dup, names (df)), collapse = ", ")
         )
-        names (df) <- fix_duplicated_columns (names (df))
+        names (df) <- cols_no_dup
     }
 
     if (nrow (df) == 0) {

--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -353,7 +353,8 @@ make_sf <- function (..., stringsAsFactors = FALSE) { # nolint
     } else { # create a data.frame from list:
         data.frame (x [-sf_column],
             row.names = row_names,
-            stringsAsFactors = stringsAsFactors
+            stringsAsFactors = stringsAsFactors,
+            check.names = FALSE
         )
     }
 
@@ -460,13 +461,15 @@ fill_kv <- function (res, kv_name, g_name, stringsAsFactors) { # nolint
         if (nrow (res [[kv_name]]) == 0) {
             res [[kv_name]] <- data.frame (
                 osm_id = names (res [[g_name]]),
-                stringsAsFactors = stringsAsFactors
+                stringsAsFactors = stringsAsFactors,
+                check.names = FALSE
             )
         } else {
             res [[kv_name]] <- data.frame (
                 osm_id = rownames (res [[kv_name]]),
                 res [[kv_name]],
-                stringsAsFactors = stringsAsFactors
+                stringsAsFactors = stringsAsFactors,
+                check.names = FALSE
             )
         }
     }

--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -799,7 +799,7 @@ xml_to_df <- function (doc, stringsAsFactors = FALSE) {
         }
         out
     })
-    keys<- sort (unique (unlist(keysL)))
+    keys <- sort (unique (unlist(keysL)))
 
     tags <- mapply (function (i, k) {
         i <- i[, k] # remove osm_id column if exists

--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -802,7 +802,7 @@ xml_to_df <- function (doc, stringsAsFactors = FALSE) {
     keys <- sort (unique (unlist(keysL)))
 
     tags <- mapply (function (i, k) {
-        i <- i[, k] # remove osm_id column if exists
+        i <- i[, k, drop = FALSE] # remove osm_id column if exists
         out <- data.frame (
             matrix (
                 nrow = nrow (i), ncol = length (keys),

--- a/codemeta.json
+++ b/codemeta.json
@@ -11,7 +11,7 @@
   "codeRepository": "https://github.com/ropensci/osmdata/",
   "issueTracker": "https://github.com/ropensci/osmdata/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.10.026",
+  "version": "0.1.10.027",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/tests/testthat/fixtures/osm-key_clashes.osm
+++ b/tests/testthat/fixtures/osm-key_clashes.osm
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="Overpass API">
+  <note>The data included in this document is from www.openstreetmap.org. The data is made available under ODbL.</note>
+  <meta osm_base="2017-01-25T10:52:05Z"/>
+  <node id="1" lat="1" lon="1"/>
+  <node id="2" lat="1" lon="2"/>
+  <node id="3" lat="1" lon="3"/>
+  <node id="4" lat="1" lon="4"/>
+  <node id="5" lat="1" lon="5"/>
+  <node id="6" lat="2" lon="1"/>
+  <node id="7" lat="2" lon="2"/>
+  <node id="8" lat="2" lon="3"/>
+  <node id="9" lat="2" lon="4"/>
+  <node id="10" lat="2" lon="5"/>
+  <node id="11" lat="3" lon="1">
+    <tag k="stuff" v="yes"/>
+    <tag k="junk" v="some"/>
+    <tag k="name:ca" v="Ni idea"/>
+    <tag k="osm_id" v="Why to use this tag?"/>
+    <!-- test comment for rapidxml.h tests -->
+  </node>
+  <node id="12" lat="3" lon="2"/>
+  <node id="13" lat="3" lon="3"/>
+  <node id="14" lat="3" lon="4"/>
+  <node id="15" lat="3" lon="5"/>
+  <node id="16" lat="4" lon="1"/>
+  <node id="17" lat="4" lon="2"/>
+  <node id="18" lat="4" lon="3">
+    <tag k="stuff" v="nope"/>
+    <tag k="like" v="lots"/>
+    <tag k="name:ca" v="Ves a saber"/>
+  </node>
+  <node id="19" lat="4" lon="4"/>
+  <node id="20" lat="4" lon="5"/>
+  <node id="21" lat="5" lon="1"/>
+  <node id="22" lat="5" lon="2"/>
+  <node id="23" lat="5" lon="3"/>
+  <node id="24" lat="5" lon="4"/>
+  <node id="25" lat="5" lon="5"/>
+  <way id="100">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <nd ref="4"/>
+    <tag k="highway" v="footway"/>
+    <tag k="layer" v="0"/>
+    <tag k="name:ca" v="Qui sap"/>
+  </way>
+  <way id="101">
+    <nd ref="4"/>
+    <nd ref="10"/>
+    <nd ref="15"/>
+    <nd ref="19"/>
+    <tag k="highway" v="maybe"/>
+    <tag k="name" v="blue&lt;this&gt;"/>
+    <tag k="name:ca" v="No ho se pas"/>
+    <tag k="osm_id" v="Why to use this tag?"/>
+  </way>
+  <way id="102">
+    <nd ref="19"/>
+    <nd ref="18"/>
+    <nd ref="22"/>
+    <nd ref="16"/>
+    <tag k="boat" v="yes"/>
+    <tag k="name" v="River Thames"/>
+    <tag k="name:ca" v="Riu Tàmesi"/>
+    <tag k="osm_id" v="Why to use this tag?"/>
+  </way>
+  <way id="103">
+    <nd ref="16"/>
+    <nd ref="11"/>
+    <nd ref="7"/>
+    <nd ref="1"/>
+    <tag k="foot" v="yes"/>
+    <tag k="highway" v="cycleway"/>
+  </way>
+  <way id="104">
+    <nd ref="8"/>
+    <nd ref="9"/>
+    <nd ref="14"/>
+    <nd ref="13"/>
+    <nd ref="8"/>
+  </way>
+  <relation id="1000">
+    <member type="way" ref="100" role="outer"/>
+    <member type="way" ref="101" role="outer"/>
+    <member type="way" ref="102" role="outer"/>
+    <member type="way" ref="103" role="outer"/>
+    <member type="way" ref="104" role="inner"/>
+    <tag k="name" v="big loop"/>
+    <tag k="name:ca" v="bucle gran"/>
+    <tag k="osm_id" v="Why to use this tag?"/>
+    <tag k="type" v="multipolygon"/>
+    <tag k="something" v="stuff&amp;junk&apos;andthenwhat"/>
+  </relation>
+  <relation id="2000">
+    <member type="way" ref="100" role=""/>
+    <member type="way" ref="101" role=""/>
+    <member type="way" ref="102" role=""/>
+    <tag k="name" v="big loop"/>
+    <tag k="name:ca" v="bucle gran"/>
+    <tag k="osm_id" v="Why to use this tag?"/>
+    <tag k="type" v="route"/>
+    <tag k="something" v="stuff&apos;&quot;aa&quot;"/>
+  </relation>
+</osm>

--- a/tests/testthat/fixtures/osm-multi.osm
+++ b/tests/testthat/fixtures/osm-multi.osm
@@ -15,6 +15,7 @@
   <node id="11" lat="3" lon="1">
     <tag k="stuff" v="yes"/>
     <tag k="junk" v="some"/>
+    <tag k="name:ca" v="Ni idea"/>
     <!-- test comment for rapidxml.h tests -->
   </node>
   <node id="12" lat="3" lon="2"/>
@@ -26,6 +27,7 @@
   <node id="18" lat="4" lon="3">
     <tag k="stuff" v="nope"/>
     <tag k="like" v="lots"/>
+    <tag k="name:ca" v="Ves a saber"/>
   </node>
   <node id="19" lat="4" lon="4"/>
   <node id="20" lat="4" lon="5"/>
@@ -41,6 +43,7 @@
     <nd ref="4"/>
     <tag k="highway" v="footway"/>
     <tag k="layer" v="0"/>
+    <tag k="name:ca" v="Qui sap"/>
   </way>
   <way id="101">
     <nd ref="4"/>
@@ -49,6 +52,7 @@
     <nd ref="19"/>
     <tag k="highway" v="maybe"/>
     <tag k="name" v="blue&lt;this&gt;"/>
+    <tag k="name:ca" v="No ho se pas"/>
   </way>
   <way id="102">
     <nd ref="19"/>
@@ -57,6 +61,7 @@
     <nd ref="16"/>
     <tag k="boat" v="yes"/>
     <tag k="name" v="River Thames"/>
+    <tag k="name:ca" v="Riu Tàmesi"/>
   </way>
   <way id="103">
     <nd ref="16"/>
@@ -80,6 +85,7 @@
     <member type="way" ref="103" role="outer"/>
     <member type="way" ref="104" role="inner"/>
     <tag k="name" v="big loop"/>
+    <tag k="name:ca" v="bucle gran"/>
     <tag k="type" v="multipolygon"/>
     <tag k="something" v="stuff&amp;junk&apos;andthenwhat"/>
   </relation>
@@ -88,6 +94,7 @@
     <member type="way" ref="101" role=""/>
     <member type="way" ref="102" role=""/>
     <tag k="name" v="big loop"/>
+    <tag k="name:ca" v="bucle gran"/>
     <tag k="type" v="route"/>
     <tag k="something" v="stuff&apos;&quot;aa&quot;"/>
   </relation>

--- a/tests/testthat/test-data_frame-osm.R
+++ b/tests/testthat/test-data_frame-osm.R
@@ -326,3 +326,11 @@ test_that ("adiff2", {
     expect_identical (metaL$meta_overpass_call, metaL$meta_opq)
     expect_identical (metaL$meta_overpass_call$datetime_from, attr (q, "datetime"))
 })
+
+test_that ("non-valid key names", {
+    osm_multi <- test_path ("fixtures", "osm-multi.osm")
+    q0 <- opq (bbox = c (1, 1, 5, 5))
+    x <- osmdata_data_frame (q0, osm_multi)
+
+    expect_true ("name:ca" %in% names(x))
+})

--- a/tests/testthat/test-data_frame-osm.R
+++ b/tests/testthat/test-data_frame-osm.R
@@ -334,3 +334,15 @@ test_that ("non-valid key names", {
 
     expect_true ("name:ca" %in% names(x))
 })
+
+test_that ("clashes in key names", {
+    osm_multi_key_clashes <- test_path ("fixtures", "osm-key_clashes.osm")
+    q0 <- opq (bbox = c (1, 1, 5, 5))
+    expect_warning (
+        x <- osmdata_data_frame (q0, osm_multi_key_clashes),
+        "Feature keys clash with id or metadata columns and will be renamed by "
+    )
+
+    expect_true (all (c ("osm_id", "osm_id.1") %in% names(x)))
+    expect_false (any (duplicated (names (x))))
+})

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -152,28 +152,28 @@ test_that ("points-from-multipolygons", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     pts <- osm_points (x, rownames (x$osm_multipolygons))
-    expect_equal (dim (pts), c (16, 5))
+    expect_equal (dim (pts), c (16, 6))
 })
 
 test_that ("points-from-multilines", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     pts <- osm_points (x, rownames (x$osm_multilines))
-    expect_equal (dim (pts), c (10, 5))
+    expect_equal (dim (pts), c (10, 6))
 })
 
 test_that ("points-from-polygons", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     pts <- osm_points (x, rownames (x$osm_polygons))
-    expect_equal (dim (pts), c (4, 5))
+    expect_equal (dim (pts), c (4, 6))
 })
 
 test_that ("points-from-lines", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     pts <- osm_points (x, rownames (x$osm_lines))
-    expect_equal (dim (pts), c (12, 5))
+    expect_equal (dim (pts), c (12, 6))
 
     # Only lines have multiples features
     ids <- lapply (seq (x$osm_lines$geometry), function (i) {
@@ -193,28 +193,28 @@ test_that ("lines-from-multipolygons", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     lns <- osm_lines (x, rownames (x$osm_multipolygons))
-    expect_equal (dim (lns), c (4, 7))
+    expect_equal (dim (lns), c (4, 8))
 })
 
 test_that ("lines-from-multilines", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     lns <- osm_lines (x, rownames (x$osm_multilines))
-    expect_equal (dim (lns), c (3, 7))
+    expect_equal (dim (lns), c (3, 8))
 })
 
 test_that ("lines-from-lines", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     lns <- osm_lines (x, rownames (x$osm_lines) [1])
-    expect_equal (dim (lns), c (3, 7))
+    expect_equal (dim (lns), c (3, 8))
 })
 
 test_that ("lines-from-points", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     lns <- osm_lines (x, rownames (x$osm_points) [1])
-    expect_equal (dim (lns), c (2, 7))
+    expect_equal (dim (lns), c (2, 8))
 })
 
 # ------------------- polygons
@@ -223,7 +223,7 @@ test_that ("polygons-from-multipolygons", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     pls <- osm_polygons (x, rownames (x$osm_multipolygons))
-    expect_equal (dim (pls), c (1, 7))
+    expect_equal (dim (pls), c (1, 8))
 })
 
 test_that ("polygons-from-multilines", {
@@ -239,14 +239,14 @@ test_that ("polygons-from-lines", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     pls <- osm_polygons (x, rownames (x$osm_lines) [1])
-    expect_equal (dim (pls), c (0, 7)) # no polygons contain lines
+    expect_equal (dim (pls), c (0, 8)) # no polygons contain lines
 })
 
 test_that ("polygons-from-points", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     pls <- osm_polygons (x, rownames (x$osm_points) [8])
-    expect_equal (dim (pls), c (1, 7))
+    expect_equal (dim (pls), c (1, 8))
 })
 
 # ------------------- multilines
@@ -255,14 +255,14 @@ test_that ("multilines-from-lines", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     mls <- osm_multilines (x, rownames (x$osm_lines) [1])
-    expect_equal (dim (mls), c (1, 6))
+    expect_equal (dim (mls), c (1, 7))
 })
 
 test_that ("multilines-from-points", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     mls <- osm_multilines (x, rownames (x$osm_points) [1])
-    expect_equal (dim (mls), c (1, 6))
+    expect_equal (dim (mls), c (1, 7))
 })
 
 # ------------------- multipolygons
@@ -271,19 +271,19 @@ test_that ("multipolygons-from-polygons", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     mps <- osm_multipolygons (x, rownames (x$osm_polygons) [1])
-    expect_equal (dim (mps), c (1, 5))
+    expect_equal (dim (mps), c (1, 6))
 })
 
 test_that ("multipolygons-from-lines", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     mps <- osm_multipolygons (x, rownames (x$osm_lines) [2])
-    expect_equal (dim (mps), c (1, 5))
+    expect_equal (dim (mps), c (1, 6))
 })
 
 test_that ("multipolygons-from-points", {
     q0 <- opq (bbox = c (1, 1, 5, 5))
     x <- osmdata_sf (q0, test_path ("fixtures", "osm-multi.osm"))
     mps <- osm_multipolygons (x, rownames (x$osm_points) [1])
-    expect_equal (dim (mps), c (1, 5))
+    expect_equal (dim (mps), c (1, 6))
 })

--- a/tests/testthat/test-sc-osm.R
+++ b/tests/testthat/test-sc-osm.R
@@ -24,3 +24,14 @@ test_that ("ways", {
     expect_is (x, "SC")
     expect_equal (names (x), sc_names)
 })
+
+
+test_that ("non-valid key names", {
+    osm_multi <- test_path ("fixtures", "osm-multi.osm")
+    q0 <- opq (bbox = c (1, 1, 5, 5))
+    x <- osmdata_sc (q0, osm_multi)
+
+    k<- lapply (x[c ("nodes", "relation_properties", "object")], function (f) {
+        expect_true ("name:ca" %in% f$key)
+    })
+})

--- a/tests/testthat/test-sc-osm.R
+++ b/tests/testthat/test-sc-osm.R
@@ -35,3 +35,13 @@ test_that ("non-valid key names", {
         expect_true ("name:ca" %in% f$key)
     })
 })
+
+# test_that ("clashes in key names", {
+#     osm_multi_key_clashes <- test_path ("fixtures", "osm-key_clashes.osm")
+#     q0 <- opq (bbox = c (1, 1, 5, 5))
+#     x <- osmdata_sc (q0, osm_multi_key_clashes)
+#
+#     k <- lapply (x[c ("nodes", "relation_properties", "object")], function (f) {
+#         expect_false (any ( duplicated (f$key)))
+#     })
+# })

--- a/tests/testthat/test-sf-osm.R
+++ b/tests/testthat/test-sf-osm.R
@@ -137,3 +137,19 @@ test_that ("non-valid key names", {
         expect_true ("name:ca" %in% names (f))
     })
 })
+
+test_that ("clashes in key names", {
+    osm_multi_key_clashes <- test_path ("fixtures", "osm-key_clashes.osm")
+    q0 <- opq (bbox = c (1, 1, 5, 5))
+    expect_warning(
+        x <- osmdata_sf (q0, osm_multi_key_clashes),
+        "Feature keys clash with id or metadata columns and will be renamed by "
+    )
+
+    expect_false (any (duplicated (names (x$osm_points))))
+    # x$osm_points don't have osm_id column in tags TODO?
+    k <- lapply (x[grep ("osm_", names (x))[-1]], function (f) {
+        expect_false (any (duplicated (names (f))))
+        expect_true (all (c ("osm_id", "osm_id.1") %in% names (f)))
+    })
+})

--- a/tests/testthat/test-sf-osm.R
+++ b/tests/testthat/test-sf-osm.R
@@ -126,3 +126,14 @@ test_that ("ways", {
         expect_identical (attr (g, a), attr (g_sf, a))
     }
 })
+
+
+test_that ("non-valid key names", {
+    osm_multi <- test_path ("fixtures", "osm-multi.osm")
+    q0 <- opq (bbox = c (1, 1, 5, 5))
+    x <- osmdata_sf (q0, osm_multi)
+
+    k <- lapply (x[grep ("osm_", names(x))], function (f) {
+        expect_true ("name:ca" %in% names (f))
+    })
+})

--- a/tests/testthat/test-sp-osm.R
+++ b/tests/testthat/test-sp-osm.R
@@ -124,3 +124,13 @@ test_that ("ways", {
         expect_identical (attributes (xyi), attributes (xyi_sp))
     }
 })
+
+test_that ("non-valid key names", {
+    osm_multi <- test_path ("fixtures", "osm-multi.osm")
+    q0 <- opq (bbox = c (1, 1, 5, 5))
+    x <- osmdata_sp (q0, osm_multi)
+
+    k <- lapply (x[grep ("osm_", names (x))], function (f) {
+        expect_true("name:ca" %in% names(f))
+    })
+})

--- a/tests/testthat/test-sp-osm.R
+++ b/tests/testthat/test-sp-osm.R
@@ -134,3 +134,19 @@ test_that ("non-valid key names", {
         expect_true("name:ca" %in% names(f))
     })
 })
+
+test_that ("clashes in key names", {
+    osm_multi_key_clashes <- test_path ("fixtures", "osm-key_clashes.osm")
+    q0 <- opq (bbox = c (1, 1, 5, 5))
+    expect_warning(
+        x <- osmdata_sp (q0, osm_multi_key_clashes),
+        "Feature keys clash with id or metadata columns and will be renamed by "
+    )
+
+    expect_false (any (duplicated (names (x$osm_points))))
+    # x$osm_points don't have osm_id column in tags TODO?
+    k <- lapply (x[grep ("osm_", names (x))[-1]], function (f) {
+        expect_false (any (duplicated (names (f))))
+        expect_true (all (c ("osm_id", "osm_id.1") %in% names (f)))
+    })
+})


### PR DESCRIPTION
FIX #301 and handle cases with clashes between OSM keys and id or metadata columns