### PR TITLE
Fix queries with !match_case and only one value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 0.2.1.00x (dev version)
 ===================
 
+## Minor changes
+
+- Fix queries with !match_case and only one value (#317)
 
 0.2.1
 ===================

--- a/R/opq.R
+++ b/R/opq.R
@@ -210,7 +210,7 @@ paste_features <- function (key, value, key_pre = "", bind = "=",
 
     } else {
 
-        if (length (value) > 1) {
+        if (length (value) > 1 || !match_case) {
 
             # convert to OR'ed regex:
             value <- paste (value, collapse = "|")

--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -41,7 +41,7 @@ test_that ("add feature", {
     )
     qry4 <- add_osm_feature (qry, key = "highway", value = "!primary")
     qry5 <- add_osm_feature (qry,
-        key = "highway", value = "!primary",
+        key = "highway", value = "primary",
         match_case = FALSE
     )
     expect_identical (qry1$features, "[\"highway\"]")
@@ -51,7 +51,7 @@ test_that ("add feature", {
         "[\"highway\"~\"^(primary|tertiary)$\"]"
     )
     expect_identical (qry4$features, "[\"highway\"!=\"primary\"]")
-    expect_identical (qry5$features, "[\"highway\"!=\"primary\",i]")
+    expect_identical (qry5$features, "[\"highway\"~\"^(primary)$\",i]")
 
     bbox <- c (-0.118, 51.514, -0.115, 51.517)
     qry <- opq (bbox = bbox)


### PR DESCRIPTION
The filter requires a ~ bind operator instead of =