### PR TITLE
Fix queries with multiple features and more than one osm_types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 0.2.1.00x (dev version)
 ===================
 
+## Minor changes
+
+- Fix queries with multiple features & multiple osm_types (#318)
 
 0.2.1
 ===================

--- a/R/opq.R
+++ b/R/opq.R
@@ -877,10 +877,20 @@ opq_string_intern <- function (opq, quiet = TRUE) {
 
         } else {
 
+            types_features <- expand.grid (
+                osm_types=opq$osm_types,
+                features=features,
+                stringsAsFactors = FALSE
+            )
+
             if (!map_to_area) {
                 features <-  c (sprintf ("  %s %s (%s);\n",
-                                         opq$osm_types, features, opq$bbox)
+                                         types_features$osm_types,
+                                         types_features$features,
+                                         opq$bbox
+                                )
                 )
+
             } else {
                 opq$prefix <- gsub ("\n$", "", opq$prefix)
                 search_area <- paste0 (
@@ -889,7 +899,10 @@ opq_string_intern <- function (opq, quiet = TRUE) {
                 )
                 features <- c (
                     search_area,
-                    sprintf ("  %s %s (area.searchArea);\n", opq$osm_types, features)
+                    sprintf ("  %s %s (area.searchArea);\n",
+                             types_features$osm_types,
+                             types_features$features
+                    )
                 )
             }
         }

--- a/tests/testthat/test-opq.R
+++ b/tests/testthat/test-opq.R
@@ -121,18 +121,35 @@ test_that ("osm_types", {
     )
     expect_true ("nwr" == q1$osm_types)
 
+    features <- c (
+        "\"amenity\"=\"school\"",
+        "\"amenity\"=\"kindergarten\"",
+        "\"amenity\"=\"music_school\"",
+        "\"amenity\"=\"language_school\"",
+        "\"amenity\"=\"dancing_school\""
+    )
+    q2 <- opq ("Catalunya") %>%
+        add_osm_features(features = features)
+    s <- opq_string (q2)
+
+    n_fts <- length (features)
+    n_fts_in_query <- length (gregexpr ("amenity", s) [[1]])
+    # Query should have that number repeated for each osm_types (default to
+    # node, way, relation):
+    expect_equal (n_fts_in_query, n_fts * length(q2$osm_types))
+
     # nodes_only
-    q2 <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517), nodes_only = TRUE)
+    q3 <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517), nodes_only = TRUE)
     expect_silent (
-        q3 <- opq (
+        q4 <- opq (
             bbox = c (-0.118, 51.514, -0.115, 51.517),
             nodes_only = TRUE,
             osm_types = "blah" # ignored if nodes_only == TRUE
         )
     )
 
-    expect_identical (q2, q3)
-    expect_true (q3$osm_types == "node")
+    expect_identical (q3, q4)
+    expect_true (q4$osm_types == "node")
 })
 
 test_that ("out", {


### PR DESCRIPTION
Example of the error for osm_types and features with non-multiple lengths
``` r
q <- opq("Catalunya") |> 
    add_osm_features(features = c("\"amenity\"=\"school\"",
                                  "\"amenity\"=\"kindergarten\"",
                                  "\"amenity\"=\"music_school\"",
                                  "\"amenity\"=\"language_school\"",
                                  "\"amenity\"=\"dancing_school\""))
opq_string(q)
#> Error in sprintf("  %s %s (%s);\n", opq$osm_types, features, opq$bbox) :
#>  arguments cannot be recycled to the same length
```

For osm_types and features with multiple lengths, every feature gets only one osm_type instead of all osm_types

``` r
q <- opq("Catalunya") |> 
    add_osm_features(features = c("\"amenity\"=\"school\"",
                              "\"amenity\"=\"kindergarten\"",
                              "\"amenity\"=\"music_school\""))
cat(opq_string(q))
#> [out:xml][timeout:25];
#> (
#>   node ["amenity"="school"] (40.5229822,0.1594133,42.8615226,3.3222508);
#>   way ["amenity"="kindergarten"] (40.5229822,0.1594133,42.8615226,3.3222508);
#>   relation ["amenity"="music_school"] (40.5229822,0.1594133,42.8615226,3.3222508);
#> );
#> (._;>;);
#> out body;
```