### PR TITLE
describe key-only queries in readme; closes #342

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: osmdata
 Title: Import 'OpenStreetMap' Data as Simple Features or Spatial Objects
-Version: 0.2.5.017
+Version: 0.2.5.018
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre")),
     person("Bob", "Rudis", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 - Improved `get_bb(..., format_out = "sf_polygon")` to return full metadata
   along with geometries (#338 thanks to @RegularnaMatrica)
+- Mention key-only feature requests in README (#342 thanks to @joostschouppe)
 
 
 0.2.5

--- a/README.Rmd
+++ b/README.Rmd
@@ -157,10 +157,21 @@ q <- opq ("portsmouth usa") %>%
     add_osm_feature (key = "amenity", value = "restaurant") %>%
     add_osm_feature (key = "amenity", value = "pub") # There are none of these
 ```
+
+Features can also be requested by key only, in which case features with any
+values for the specified key will be returned:
+```{r key-val2}
+q <- opq ("portsmouth usa") %>%
+    add_osm_feature (key = "amenity")
+```
+Such key-only queries can, however, translate into requesting very large data
+sets, and should generally be avoided in favour of more precise key-value
+specifications.
+
 Negation can also be specified by pre-pending an exclamation mark so that the
 following requests all amenities that are NOT labelled as restaurants and that
 are not labelled as pubs:
-```{r key-val2}
+```{r key-val3}
 q <- opq ("portsmouth usa") %>%
     add_osm_feature (key = "amenity", value = "!restaurant") %>%
     add_osm_feature (key = "amenity", value = "!pub") # There are a lot of these
@@ -168,7 +179,7 @@ q <- opq ("portsmouth usa") %>%
 
 Additional arguments allow for more refined matching, such as the following
 request for all pubs with "irish" in the name:
-```{r key-val3}
+```{r key-val4}
 q <- opq ("washington dc") %>%
     add_osm_feature (key = "amenity", value = "pub") %>%
     add_osm_feature (

--- a/README.md
+++ b/README.md
@@ -60,11 +60,8 @@ To load the package and check the version:
 ``` r
 library (osmdata)
 #> Data (c) OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright
-```
-
-``` r
 packageVersion ("osmdata")
-#> [1] '0.2.5.17'
+#> [1] '0.2.5.16'
 ```
 
 ## Usage
@@ -133,9 +130,6 @@ boxes:
 b <- getbb ("bangalore", format_out = "polygon")
 class (b)
 #> [1] "matrix" "array"
-```
-
-``` r
 head (b [[1]])
 #> [1] 77.46005
 ```
@@ -157,6 +151,18 @@ q <- opq ("portsmouth usa") %>%
     add_osm_feature (key = "amenity", value = "restaurant") %>%
     add_osm_feature (key = "amenity", value = "pub") # There are none of these
 ```
+
+Features can also be requested by key only, in which case features with
+any values for the specified key will be returned:
+
+``` r
+q <- opq ("portsmouth usa") %>%
+    add_osm_feature (key = "amenity")
+```
+
+Such key-only queries can, however, translate into requesting very large
+data sets, and should generally be avoided in favour of more precise
+key-value specifications.
 
 Negation can also be specified by pre-pending an exclamation mark so
 that the following requests all amenities that are NOT labelled as

--- a/codemeta.json
+++ b/codemeta.json
@@ -11,7 +11,7 @@
   "codeRepository": "https://github.com/ropensci/osmdata/",
   "issueTracker": "https://github.com/ropensci/osmdata/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.5.017",
+  "version": "0.2.5.018",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
@joostschouppe This adds a clear example early on in the README. Do you think that clarifies the issue?