### PR TITLE
Fix bug when parsing dates and remove lubridate form imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Depends:
 Imports:
     curl,
     httr2,
-    lubridate,
     magrittr,
     methods,
     Rcpp (>= 0.12.4),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: osmdata
 Title: Import 'OpenStreetMap' Data as Simple Features or Spatial Objects
-Version: 0.2.5.033
+Version: 0.2.5.034
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre")),
     person("Bob", "Rudis", role = "aut"),
@@ -58,7 +58,7 @@ VignetteBuilder:
 Encoding: UTF-8
 NeedsCompilation: yes
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 X-schema.org-applicationCategory: Data Access
 X-schema.org-isPartOf: https://ropensci.org
 X-schema.org-keywords: open0street0map, openstreetmap, overpass0API, OSM

--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -24,12 +24,12 @@ get_timestamp <- function (doc) {
     }
 
     wday_t <- lubridate::wday (tstmp, label = TRUE)
-    wday <- lubridate::wday (tstmp, label = FALSE)
+    mday <- lubridate::mday (tstmp)
     mon <- lubridate::month (tstmp, label = TRUE)
     year <- lubridate::year (tstmp)
 
     hms <- strsplit (as.character (tstmp), " ") [[1]] [2]
-    paste ("[", wday_t, wday, mon, year, hms, "]")
+    paste ("[", wday_t, mday, mon, year, hms, "]")
 }
 
 

--- a/R/get-osmdata.R
+++ b/R/get-osmdata.R
@@ -23,13 +23,9 @@ get_timestamp <- function (doc) {
         tstmp <- Sys.time ()
     }
 
-    wday_t <- lubridate::wday (tstmp, label = TRUE)
-    mday <- lubridate::mday (tstmp)
-    mon <- lubridate::month (tstmp, label = TRUE)
-    year <- lubridate::year (tstmp)
-
-    hms <- strsplit (as.character (tstmp), " ") [[1]] [2]
-    paste ("[", wday_t, mday, mon, year, hms, "]")
+    out <- paste ("[", format (tstmp, format = "%a %e %b %Y %T"), "]")
+    out <- gsub ("  ", " ", out) # remove extra space in %e for single digit days
+    out <- gsub ("\\.", "\\\\.", out) # Escape dots
 }
 
 

--- a/R/overpass-query.R
+++ b/R/overpass-query.R
@@ -46,8 +46,7 @@ overpass_status <- function (quiet = FALSE) {
         } else {
 
             # status not even returned so pause the whole shebang for 10 seconds
-            slot_time <- lubridate::ymd_hms (lubridate::now () + 10)
-            slot_time <- lubridate::force_tz (slot_time, tz = Sys.timezone ())
+            slot_time <- Sys.time () + 10
         }
     }
 
@@ -66,13 +65,12 @@ get_slot_time <- function (status, quiet) {
 
     if (grepl ("after", status_now)) {
         available <- FALSE
-        slot_time <- lubridate::ymd_hms (gsub (
-            "Slot available after: ",
-            "", status_now
-        ))
-        slot_time <- lubridate::force_tz (slot_time,
-            tz = Sys.timezone ()
+        slot_time <- strptime (
+            gsub ("Slot available after: ", "", status_now),
+            format = "%FT%TZ",
+            tz = "GMT"
         )
+        slot_time <- as.POSIXct (slot_time, tz = Sys.timezone ())
     } else {
         available <- TRUE
         slot_time <- Sys.time ()

--- a/R/overpass-query.R
+++ b/R/overpass-query.R
@@ -13,7 +13,7 @@ overpass_status <- function (quiet = FALSE) {
 
     overpass_url <- get_overpass_url ()
     st_type <- "status"
-    if (grepl ("vi-di", overpass_url) | grepl ("rambler", overpass_url)) {
+    if (grepl ("vi-di", overpass_url) || grepl ("rambler", overpass_url)) {
         st_type <- "timestamp"
     }
 
@@ -102,7 +102,7 @@ check_for_error <- function (doc) {
 
     # the nchar check uses an arbitrary value to avoid trying to `read_xml()`
     # read data, which would take forever.
-    if (grepl ("error: ", doc, ignore.case = TRUE) &
+    if (grepl ("error: ", doc, ignore.case = TRUE) &&
         nchar (doc) < 10000) {
 
         docx <- xml2::read_xml (doc)
@@ -148,7 +148,7 @@ overpass_query <- function (query, quiet = FALSE, wait = TRUE, pad_wait = 5,
     if (missing (query)) {
         stop ("query must be supplied", call. = FALSE)
     }
-    if (!is.character (query) | length (query) > 1) {
+    if (!is.character (query) || length (query) > 1) {
         stop ("query must be a single character string")
     }
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,20 +4,17 @@
   "identifier": "osmdata",
   "description": "Download and import of 'OpenStreetMap' ('OSM') data as 'sf' or 'sp' objects. 'OSM' data are extracted from the 'Overpass' web server (<https://overpass-api.de/>) and processed with very fast 'C++' routines for return to 'R'.",
   "name": "osmdata: Import 'OpenStreetMap' Data as Simple Features or Spatial Objects",
-  "relatedLink": [
-    "https://docs.ropensci.org/osmdata/",
-    "https://CRAN.R-project.org/package=osmdata"
-  ],
+  "relatedLink": ["https://docs.ropensci.org/osmdata/", "https://CRAN.R-project.org/package=osmdata"],
   "codeRepository": "https://github.com/ropensci/osmdata/",
   "issueTracker": "https://github.com/ropensci/osmdata/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.2.5.033",
+  "version": "0.2.5.34",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.4.1 (2024-06-14)",
+  "runtimePlatform": "R version 4.5.0 (2025-04-11)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -255,18 +252,6 @@
     },
     "4": {
       "@type": "SoftwareApplication",
-      "identifier": "lubridate",
-      "name": "lubridate",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=lubridate"
-    },
-    "5": {
-      "@type": "SoftwareApplication",
       "identifier": "magrittr",
       "name": "magrittr",
       "provider": {
@@ -277,12 +262,12 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=magrittr"
     },
-    "6": {
+    "5": {
       "@type": "SoftwareApplication",
       "identifier": "methods",
       "name": "methods"
     },
-    "7": {
+    "6": {
       "@type": "SoftwareApplication",
       "identifier": "Rcpp",
       "name": "Rcpp",
@@ -295,7 +280,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=Rcpp"
     },
-    "8": {
+    "7": {
       "@type": "SoftwareApplication",
       "identifier": "reproj",
       "name": "reproj",
@@ -307,7 +292,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=reproj"
     },
-    "9": {
+    "8": {
       "@type": "SoftwareApplication",
       "identifier": "rvest",
       "name": "rvest",
@@ -319,7 +304,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=rvest"
     },
-    "10": {
+    "9": {
       "@type": "SoftwareApplication",
       "identifier": "tibble",
       "name": "tibble",
@@ -331,12 +316,12 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=tibble"
     },
-    "11": {
+    "10": {
       "@type": "SoftwareApplication",
       "identifier": "utils",
       "name": "utils"
     },
-    "12": {
+    "11": {
       "@type": "SoftwareApplication",
       "identifier": "xml2",
       "name": "xml2",
@@ -348,25 +333,12 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=xml2"
     },
-    "SystemRequirements": {}
+    "SystemRequirements": null
   },
   "applicationCategory": "DataAccess",
   "isPartOf": "https://ropensci.org",
-  "keywords": [
-    "open0street0map",
-    "openstreetmap",
-    "overpass0API",
-    "OSM",
-    "overpass-api",
-    "r",
-    "cpp",
-    "rstats",
-    "osm",
-    "osm-data",
-    "r-package",
-    "peer-reviewed"
-  ],
-  "fileSize": "17525.157KB",
+  "keywords": ["open0street0map", "openstreetmap", "overpass0API", "OSM", "overpass-api", "r", "cpp", "rstats", "osm", "osm-data", "r-package", "peer-reviewed"],
+  "fileSize": "28399.402KB",
   "citation": [
     {
       "@type": "ScholarlyArticle",
@@ -400,10 +372,7 @@
         "issueNumber": "14",
         "datePublished": "2017",
         "isPartOf": {
-          "@type": [
-            "PublicationVolume",
-            "Periodical"
-          ],
+          "@type": ["PublicationVolume", "Periodical"],
           "volumeNumber": "2",
           "name": "Journal of Open Source Software"
         }
@@ -412,10 +381,7 @@
   ],
   "releaseNotes": "https://github.com/ropensci/osmdata/blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/osmdata/blob/main/README.md",
-  "contIntegration": [
-    "https://github.com/ropensci/osmdata/actions?query=workflow%3AR-CMD-check",
-    "https://app.codecov.io/gh/ropensci/osmdata"
-  ],
+  "contIntegration": ["https://github.com/ropensci/osmdata/actions?query=workflow%3AR-CMD-check", "https://app.codecov.io/gh/ropensci/osmdata"],
   "developmentStatus": "https://www.repostatus.org/#active",
   "review": {
     "@type": "Review",


### PR DESCRIPTION
In `get_timestamp()`, the day of the week was returned instead of the day of the month (FIX #359). Also, remove lubridate from imports.

The only changes in the format of the output is in `get_timestamp()`, where the original implementation have no dot after the abbreviated month name. Month name depends on the locale, so I prefer to avoid a regex without testing for many cases.  So now, with a Catalan locale,
 `"[ dg\\. 1 de des 2022 10:56:49 ]"` 
becomes
 `"[ dg\\. 4 de des\\. 2022 10:56:49 ]"`
