### PR TITLE
Deprecate `nodes_only` argument in `opq()`. Superseeded by argument osm_types`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: osmdata
 Title: Import 'OpenStreetMap' Data as Simple Features or Spatial Objects
-Version: 0.2.5.056
+Version: 0.2.5.058
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre")),
     person("Bob", "Rudis", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - Remove `magrittr` from imports. User code relaying on reexported pipe `%>%` from `osmdata` must exlicitly load it
   with `library(magrittr)`.  Code examples, tests and vignettes now use the pipe from base (`|>`) available since R 4.1
   (#361)
+- Deprecate `nodes_only` argument in `opq()`. Superseeded by argument `osm_types` (#362)
 
 ## Minor changes
 

--- a/man/opq.Rd
+++ b/man/opq.Rd
@@ -6,7 +6,7 @@
 \usage{
 opq(
   bbox = NULL,
-  nodes_only = FALSE,
+  nodes_only = NULL,
   osm_types = c("node", "way", "relation"),
   out = c("body", "tags", "meta", "skel", "tags center", "ids"),
   datetime = NULL,
@@ -28,18 +28,17 @@ the format \code{"way(id:1)"}, \code{"relation(id:1, 2)"} or \code{"relation(id:
 or \link{bbox_to_string} with a \code{data.frame} from \code{getbb(..., format_out = "data.frame")} to select all areas combined (relations and ways).}
 
 \item{nodes_only}{WARNING: this parameter is equivalent to
-\code{osm_types = "node"} and will be DEPRECATED. If \code{TRUE}, query OSM nodes
-only. Some OSM structures such as \code{place = "city"} or
-\code{highway = "traffic_signals"} are represented by nodes only. Queries are
-built by default to return all nodes, ways, and relation, but this can
-be very inefficient for node-only queries. Setting this value to \code{TRUE}
-for such cases makes queries more efficient, with data returned in the
-\code{osm_points} list item.}
+\code{osm_types = "node"} and is DEPRECATED. If \code{TRUE}, query OSM nodes
+only.}
 
 \item{osm_types}{A character vector with several OSM types to query: \code{node},
 \code{way} and \code{relation} is the default. \code{nwr}, \code{nw}, \code{wr}, \code{nr} and \code{rel}
-are also valid types. Ignored if \code{nodes_only = TRUE}.
-\code{osm_types = "node"} is equivalent to \code{nodes_only = TRUE}.}
+are also valid types. Some OSM structures such as \code{place = "city"} or
+\code{highway = "traffic_signals"} are represented by nodes only. Queries are
+built by default to return all nodes, ways, and relation, but this can
+be very inefficient for node-only queries. Setting this value to \code{"node"}
+for such cases makes queries more efficient and, in \code{\link[=osmdata_sf]{osmdata_sf()}}, the
+data will be returned in the \code{osm_points} list item only.}
 
 \item{out}{The level of verbosity of the overpass result: \code{body} (geometries
 and tags, the default), \code{tags} (tags without geometry), \code{meta} (like
@@ -105,21 +104,21 @@ q2 <- getbb ("portsmouth", display_name_contains = "United States") |>
     add_osm_feature ("amenity", "pub")
 c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
 
-# Use nodes_only to retrieve single point data only, such as for central
+# Use `osm_types = "node"` to retrieve single point data only, such as for central
 # locations of cities.
-opq <- opq (bbox, nodes_only = TRUE) |>
+opq <- opq (bbox, osm_types = "node") |>
     add_osm_feature (key = "place", value = "city") |>
     osmdata_sf (quiet = FALSE)
 
 # Filter by a search area
 qa1 <- getbb ("Catalan Countries", format_out = "osm_type_id") |>
-    opq (nodes_only = TRUE) |>
+    opq (osm_types = "node") |>
     add_osm_feature (key = "capital", value = "4")
 opqa1 <- osmdata_sf (qa1)
 # Filter by a multiple search areas
 bb <- getbb ("Vilafranca", format_out = "data.frame")
 qa2 <- bbox_to_string (bb [bb$osm_type != "node", ]) |>
-    opq (nodes_only = TRUE) |>
+    opq (osm_types = "node") |>
     add_osm_feature (key = "place")
 opqa2 <- osmdata_sf (qa2)
 }

--- a/tests/testthat/test-data_frame-osm.R
+++ b/tests/testthat/test-data_frame-osm.R
@@ -68,7 +68,7 @@ test_that ("empty result", {
     rownames (bb) <- c ("x", "y")
     colnames (bb) <- c ("min", "max")
 
-    q0 <- opq (bb, nodes_only = TRUE, datetime = "1714-09-11T00:00:00Z") |>
+    q0 <- opq (bb, osm_types = "node", datetime = "1714-09-11T00:00:00Z") |>
         add_osm_feature ("does not exist", "&%$")
 
     osm_empty <- test_path ("fixtures", "osm-empty.osm")
@@ -100,7 +100,7 @@ test_that ("empty result", {
     # q0 <- getbb ("Països Catalans", featuretype = "relation") |>
     q0 <- opq (
         bb,
-        nodes_only = TRUE,
+        osm_types = "node",
         datetime = "1714-09-11T00:00:00Z",
         adiff = TRUE
     ) |>
@@ -176,7 +176,7 @@ test_that ("date", {
     bb <- rbind (c (2.01, 2.66), c (42.42, 42.71))
     rownames (bb) <- c ("x", "y")
     colnames (bb) <- c ("min", "max")
-    q <- opq (bb, nodes_only = TRUE, datetime = "2020-11-07T00:00:00Z") |>
+    q <- opq (bb, osm_types = "node", datetime = "2020-11-07T00:00:00Z") |>
         add_osm_feature ("natural", "peak") |>
         add_osm_feature ("prominence") |>
         add_osm_feature ("name:ca")
@@ -254,7 +254,7 @@ test_that ("out meta & diff", {
     rownames (bb) <- c ("x", "y")
     colnames (bb) <- c ("min", "max")
     q <- opq (bb,
-        nodes_only = TRUE, out = "meta",
+        osm_types = "node", out = "meta",
         datetime = "2020-11-07T00:00:00Z",
         datetime2 = "2022-12-04T00:00:00Z"
     ) |>
@@ -307,7 +307,7 @@ test_that ("out meta & adiff", {
     rownames (bb) <- c ("x", "y")
     colnames (bb) <- c ("min", "max")
     q <- opq (bb,
-        nodes_only = TRUE, out = "meta",
+        osm_types = "node", out = "meta",
         datetime = "2020-11-07T00:00:00Z", adiff = TRUE
     ) |>
         add_osm_feature ("natural", "peak") |>
@@ -416,7 +416,7 @@ test_that ("adiff2", {
     rownames (bb) <- c ("x", "y")
     colnames (bb) <- c ("min", "max")
     q <- opq (bb,
-        nodes_only = TRUE,
+        osm_types = "node",
         datetime = "2012-11-07T00:00:00Z",
         datetime2 = "2016-11-07T00:00:00Z",
         adiff = TRUE

--- a/tests/testthat/test-opq.R
+++ b/tests/testthat/test-opq.R
@@ -136,13 +136,11 @@ test_that ("osm_types", {
     expect_equal (n_fts_in_query, n_fts * length(q2$osm_types))
 
     # nodes_only
-    q3 <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517), nodes_only = TRUE)
+    q3 <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517), osm_types = "node")
     expect_silent (
         q4 <- opq (
             bbox = c (-0.118, 51.514, -0.115, 51.517),
-            nodes_only = TRUE,
-            osm_types = "blah" # ignored if nodes_only == TRUE
-        )
+            osm_types = "node"        )
     )
 
     expect_identical (q3, q4)
@@ -182,7 +180,7 @@ test_that ("out", {
     })
 
     # nodes_only
-    q1 <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517), nodes_only = TRUE)
+    q1 <- opq (bbox = c (-0.118, 51.514, -0.115, 51.517), osm_types = "node")
     expect_error (
         q <- opq (
             bbox = c (-0.118, 51.514, -0.115, 51.517),
@@ -194,7 +192,7 @@ test_that ("out", {
     q_geo <- lapply (c ("meta", "skel"), function (x) {
         q <- opq (
             bbox = c (-0.118, 51.514, -0.115, 51.517),
-            nodes_only = TRUE, out = x
+            osm_types = "node", out = x
         )
         expect_true (!identical (q1, q))
         expect_identical (names (q1), names (q))
@@ -207,7 +205,7 @@ test_that ("out", {
     q_no_geo <- lapply (c ("tags", "tags center", "ids"), function (x) {
         q <- opq (
             bbox = c (-0.118, 51.514, -0.115, 51.517),
-            nodes_only = TRUE, out = x
+            osm_types = "node", out = x
         )
         expect_true (!identical (q1, q))
         expect_identical (names (q1), names (q))
@@ -264,7 +262,7 @@ test_that ("opq_string", {
     # nodes_only parameter:
     q1 <- opq (
         bbox = c (-0.118, 51.514, -0.115, 51.517),
-        nodes_only = TRUE
+        osm_types = "node"
     )
     s1 <- opq_string (q1)
     # nodes only, so "out" instead of "out body" and no way nor relation
@@ -273,7 +271,7 @@ test_that ("opq_string", {
 
     q1 <- opq (
         bbox = "relation(id:11747082)",
-        nodes_only = TRUE
+        osm_types = "node"
     )
     s1 <- opq_string (q1)
     # nodes only, so "out" instead of "out body" and no way nor relation on clauses
@@ -283,7 +281,7 @@ test_that ("opq_string", {
     # nodes_only parameter with features:
     q1 <- opq (
         bbox = c (-0.118, 51.514, -0.115, 51.517),
-        nodes_only = TRUE
+        osm_types = "node"
     )
     q1 <- add_osm_feature (q1, key = "amenity", value = "restaurant")
     s1 <- opq_string (q1)
@@ -293,7 +291,7 @@ test_that ("opq_string", {
 
     q1 <- opq (
         bbox = "relation(id:11747082)",
-        nodes_only = TRUE
+        osm_types = "node"
     )
     q1 <- add_osm_feature (q1, key = "amenity", value = "restaurant")
     s1 <- opq_string (q1)

--- a/vignettes/osmdata.Rmd
+++ b/vignettes/osmdata.Rmd
@@ -278,7 +278,6 @@ q <- list (
     features = c ("[\"natural\"=\"water\"]", "[\"name:en\"=\"Dian\"]")
 )
 attr (q, "class") <- c ("list", "overpass_query")
-attr (q, "nodes_only") <- FALSE
 ```
 
 Note that the `"="` symbols here requests features whose values exactly match


### PR DESCRIPTION
FIX #312