### PR TITLE
Use sf functions instead of sp::point.in.polygon() in trim_osmdata()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: osmdata
 Title: Import 'OpenStreetMap' Data as Simple Features or Spatial Objects
-Version: 0.2.5.065
+Version: 0.2.5.066
 Authors@R: c(
     person("Mark", "Padgham", , "mark.padgham@email.com", role = c("aut", "cre")),
     person("Bob", "Rudis", role = "aut"),
@@ -35,7 +35,6 @@ Imports:
     httr2,
     methods,
     Rcpp (>= 0.12.4),
-    reproj,
     rvest,
     tibble,
     utils,

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 S3method(bb_poly_to_mat,SpatialPolygonsDataFrame)
 S3method(bb_poly_to_mat,default)
 S3method(bb_poly_to_mat,list)
+S3method(bb_poly_to_mat,matrix)
 S3method(bb_poly_to_mat,sf)
 S3method(bb_poly_to_mat,sfc)
 S3method(c,osmdata)

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 - Deprecate `osmdata_sp` (#372)
 - Pre-prend class names `osmdata_sf` and `osmdata` rather than append; thanks to @agila5 (#373)
 - Add `osmadata_data.frame` class to `osmdata_data_frame()` results (#378)
+- Reimplement `trim_osmdata()` using `sf` instead of `sp`. Now, it checks the full geometry instead of just the points
+  to determine if an object is properly contained in the bbox (only for `osmdata_sf` objects, `osdmata_sc` still wrong) (#382).
 
 ## Minor changes
 

--- a/man/trim_osmdata.Rd
+++ b/man/trim_osmdata.Rd
@@ -10,11 +10,12 @@ trim_osmdata(dat, bb_poly, exclude = TRUE)
 \item{dat}{An \code{osmdata} object returned from \code{\link[=osmdata_sf]{osmdata_sf()}} or
 \code{\link[=osmdata_sc]{osmdata_sc()}}.}
 
-\item{bb_poly}{A matrix representing a bounding polygon obtained with
-\code{getbb (..., format_out = "polygon")} (and possibly selected from
-resultant list where multiple polygons are returned).}
+\item{bb_poly}{An \code{sf} or \code{sfc} object, or matrix representing a bounding
+polygon. Can be obtained with \code{getbb (..., format_out = "polygon")} or
+\code{getbb (..., format_out = "sf_polygon")} (and possibly
+selected from resultant list where multiple polygons are returned).}
 
-\item{exclude}{If TRUE, objects are trimmed exclusively, only retaining those
+\item{exclude}{If \code{TRUE}, objects are trimmed exclusively, only retaining those
 strictly within the bounding polygon; otherwise all objects which partly
 extend within the bounding polygon are retained.}
 }
@@ -33,6 +34,10 @@ Caution is advised when using polygons obtained from Nominatim via
 \code{getbb(..., format_out = "polygon"|"sf_polygon")}. These shapes can be
 outdated and thus could cause the trimming operation to not give results
 expected based on the current state of the OSM data.
+
+To reduce the downloaded data from Overpass, you can do the trimming in
+the server-side using \code{getbb(..., format_out = "osm_type_id")}
+(see examples).
 }
 \examples{
 \dontrun{
@@ -52,6 +57,12 @@ dat_tr <- trim_osmdata (dat, bb_sf)
 bb_sp <- as (bb_sf, "Spatial")
 class (bb_sp) # SpatialPolygonsDataFrame
 dat_tr <- trim_osmdata (dat, bb_sp)
+
+# Server-side trimming equivalent
+bb <- getbb ("colchester uk", format_out = "osm_type_id")
+query <- opq (bb) |>
+    add_osm_feature (key = "highway")
+dat <- osmdata_sf (query, quiet = FALSE)
 }
 }
 \seealso{

--- a/tests/testthat/test-trim.R
+++ b/tests/testthat/test-trim.R
@@ -13,18 +13,15 @@ test_that ("trim_osm_data", {
         trim_osmdata (1, bb_poly = bb),
         "unrecognised dat class: numeric"
     )
-    expect_silent (x1 <- trim_osmdata (x0, bb_poly = bb))
+    expect_silent (x1 <- trim_osmdata (x0, bb_poly = bb, exclude = TRUE))
     expect_equal (nrow (x1$osm_points), 0)
     expect_equal (nrow (x1$osm_lines), 0)
     expect_equal (nrow (x1$osm_polygons), 0)
     expect_equal (nrow (x1$osm_multilines), 0)
     expect_equal (nrow (x1$osm_multipolygons), 0)
 
-    expect_silent (x1 <- trim_osmdata (x0,
-        bb_poly = bb,
-        exclude = FALSE
-    ))
-    expect_equal (nrow (x1$osm_points), 2)
+    expect_silent (x1 <- trim_osmdata (x0, bb_poly = bb, exclude = FALSE))
+    expect_equal (nrow (x1$osm_points), 4)
     expect_equal (nrow (x1$osm_lines), 1)
     expect_equal (nrow (x1$osm_polygons), 1)
     expect_equal (nrow (x1$osm_multilines), 0)
@@ -81,7 +78,7 @@ test_that ("bb_poly as sf/sc", {
 
     bb_sf <- sf::st_polygon (list (bb)) |>
         st_sfc () |>
-        st_sf ()
+        st_sf (crs = 4326)
     expect_silent (x2 <- trim_osmdata (x0,
         bb_poly = bb_sf,
         exclude = FALSE


### PR DESCRIPTION
+ improve behavior: now check the full geometry instead of just the points to determine if an objects is properly contained in the bbox (only for osmdata_sf objects, osdmata_sc still wrong).