### PR TITLE
Add examples to osm_add_features()

### DIFF
--- a/R/opq.R
+++ b/R/opq.R
@@ -305,6 +305,7 @@ paste_features <- function (key, value, key_pre = "", bind = "=",
 #' q2 <- opq ("portsmouth usa") |>
 #'     add_osm_feature (key = "amenity", value = "pub")
 #' c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
+#'
 #' # Use of negation to extract all non-primary highways
 #' q <- opq ("portsmouth uk") |>
 #'     add_osm_feature (key = "highway", value = "!primary")
@@ -312,9 +313,17 @@ paste_features <- function (key, value, key_pre = "", bind = "=",
 #' # key negation without warnings
 #' q3 <- opq ("Vinçà", osm_type = "node") |>
 #'     add_osm_feature (key = c ("name", "!name:ca"))
+#' cat (opq_string (q3))
 #' q4 <- opq ("el Carxe", osm_type = "node") |>
 #'     add_osm_feature (key = "natural", value = "peak") |>
 #'     add_osm_feature (key = "!ele")
+#' cat (opq_string (q4))
+#'
+#' # Get objects with keys (`natural` OR `waterway`) AND `name`
+#' q_keys <- opq ("Badia del Vallès", osm_types = "nwr", out = "tags") |>
+#'     add_osm_features (features = list (natural = NULL, waterway = NULL)) |>
+#'     add_osm_feature (key = "name")
+#' cat (opq_string (q_keys))
 #' }
 add_osm_feature <- function (opq,
                              key,
@@ -501,6 +510,7 @@ check_bind_key_pre <- function (bind = "=", key_pre = "") {
 #'         "\"amenity\"=\"restaurant\"",
 #'         "\"amenity\"=\"pub\""
 #'     ))
+#' cat (opq_string (q))
 #' # This extracts in a single query the same result as the following:
 #' q1 <- opq ("portsmouth usa") |>
 #'     add_osm_feature (
@@ -510,6 +520,12 @@ check_bind_key_pre <- function (bind = "=", key_pre = "") {
 #' q2 <- opq ("portsmouth usa") |>
 #'     add_osm_feature (key = "amenity", value = "pub")
 #' c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
+#'
+#' # Get objects with keys (`natural` OR `waterway`) AND `name`
+#' q_keys <- opq ("Badia del Vallès", osm_types = "nwr", out = "tags") |>
+#'     add_osm_features (features = list (natural = NULL, waterway = NULL)) |>
+#'     add_osm_feature (key = "name")
+#' cat (opq_string (q_keys))
 #' }
 add_osm_features <- function (opq,
                               features,

--- a/R/opq.R
+++ b/R/opq.R
@@ -126,9 +126,11 @@ opq <- function (bbox = NULL, nodes_only,
                 "nwr", "nw", "wr", "nr"
             ),
             several.ok = TRUE
-    ), silent = TRUE)
+        ),
+        silent = TRUE
+    )
     if (inherits (osm_types, "try-error")) {
-        stop ('osm_types parameter must be a vector with values from ',
+        stop ("osm_types parameter must be a vector with values from ",
             '"node", "way", "rel", "relation", ',
             '"nwr", "nw", "wr" and "nr".',
             call. = FALSE
@@ -209,8 +211,8 @@ paste_features <- function (key, value, key_pre = "", bind = "=",
     if (is.null (value)) {
 
         feature <- ifelse (substring (key, 1, 1) == "!",
-                sprintf ('[!"%s"]', substring (key, 2, nchar (key))),
-                sprintf ('["%s"]', key)
+            sprintf ('[!"%s"]', substring (key, 2, nchar (key))),
+            sprintf ('["%s"]', key)
         )
 
     } else {
@@ -363,10 +365,10 @@ add_osm_feature <- function (opq,
         opq$features <- paste (opq$features, feature)
     }
 
-    if (any (w <- !grepl("\\[(\\\"|~)", opq$features))) {
-        warning(
+    if (any (w <- !grepl ("\\[(\\\"|~)", opq$features))) {
+        warning (
             "The query will request objects whith only a negated key (",
-            paste (opq$features[w], collapse = ", "), ") , which can be quite ",
+            paste (opq$features [w], collapse = ", "), ") , which can be quite ",
             "expensive for overpass servers. Add other features or be shure ",
             "that that is what you want. To avoid this warning, reorder your ",
             "calls to add_osm_feature/s and leave key negations at the end."
@@ -555,9 +557,12 @@ add_osm_features <- function (opq,
                 key_exact = key_exact
             )
 
-        features <- mapply (function (key, value, key_pre, bind) {
-                paste_features (key, value, key_pre = key_pre, bind = bind,
-                    match_case = TRUE, value_exact = value_exact)
+        features <- mapply (
+            function (key, value, key_pre, bind) {
+                paste_features (key, value,
+                    key_pre = key_pre, bind = bind,
+                    match_case = TRUE, value_exact = value_exact
+                )
             },
             key = names (features), value = features,
             key_pre = bind_key_pre$key_pre, bind = bind_key_pre$bind,
@@ -880,13 +885,13 @@ opq_csv <- function (q, fields, header = TRUE) {
         stop ("fields must be a character vector.")
     }
 
-    fields <- vapply(fields, function (x) {
-        if (substr(x, 1, 2) != "::") {
-            x <- paste0("\"", x, "\"")
+    fields <- vapply (fields, function (x) {
+        if (substr (x, 1, 2) != "::") {
+            x <- paste0 ("\"", x, "\"")
         }
         return (x)
-    }, FUN.VALUE = character(1), USE.NAMES = FALSE)
-    fields <- paste (fields, collapse=", ")
+    }, FUN.VALUE = character (1), USE.NAMES = FALSE)
+    fields <- paste (fields, collapse = ", ")
 
     csv_prefix <- paste0 (
         "[out:csv(", fields,
@@ -970,18 +975,18 @@ opq_string_intern <- function (opq, quiet = TRUE) {
         } else {
 
             types_features <- expand.grid (
-                osm_types=opq$osm_types,
-                features=features,
+                osm_types = opq$osm_types,
+                features = features,
                 stringsAsFactors = FALSE
             )
 
             if (!map_to_area) {
-                features <-  c (sprintf ("  %s %s (%s);\n",
-                                         types_features$osm_types,
-                                         types_features$features,
-                                         opq$bbox
-                                )
-                )
+                features <- c (sprintf (
+                    "  %s %s (%s);\n",
+                    types_features$osm_types,
+                    types_features$features,
+                    opq$bbox
+                ))
 
             } else {
                 opq$prefix <- gsub ("\n$", "", opq$prefix)
@@ -991,9 +996,10 @@ opq_string_intern <- function (opq, quiet = TRUE) {
                 )
                 features <- c (
                     search_area,
-                    sprintf ("  %s %s (area.searchArea);\n",
-                             types_features$osm_types,
-                             types_features$features
+                    sprintf (
+                        "  %s %s (area.searchArea);\n",
+                        types_features$osm_types,
+                        types_features$features
                     )
                 )
             }

--- a/man/add_osm_feature.Rd
+++ b/man/add_osm_feature.Rd
@@ -88,17 +88,17 @@ q <- opq ("portsmouth uk") |>
 # key negation without warnings
 q3 <- opq ("Vinçà", osm_type = "node") |>
     add_osm_feature (key = c ("name", "!name:ca"))
-cat(opq_string(q3))
+cat (opq_string (q3))
 q4 <- opq ("el Carxe", osm_type = "node") |>
     add_osm_feature (key = "natural", value = "peak") |>
     add_osm_feature (key = "!ele")
-cat(opq_string(q4))
+cat (opq_string (q4))
 
 # Get objects with keys (`natural` OR `waterway`) AND `name`
 q_keys <- opq ("Badia del Vallès", osm_types = "nwr", out = "tags") |>
     add_osm_features (features = list (natural = NULL, waterway = NULL)) |>
     add_osm_feature (key = "name")
-cat(opq_string(q_keys))
+cat (opq_string (q_keys))
 }
 }
 \references{

--- a/man/add_osm_feature.Rd
+++ b/man/add_osm_feature.Rd
@@ -80,6 +80,7 @@ q1 <- opq ("portsmouth usa") |>
 q2 <- opq ("portsmouth usa") |>
     add_osm_feature (key = "amenity", value = "pub")
 c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
+
 # Use of negation to extract all non-primary highways
 q <- opq ("portsmouth uk") |>
     add_osm_feature (key = "highway", value = "!primary")
@@ -87,9 +88,17 @@ q <- opq ("portsmouth uk") |>
 # key negation without warnings
 q3 <- opq ("Vinçà", osm_type = "node") |>
     add_osm_feature (key = c ("name", "!name:ca"))
+cat(opq_string(q3))
 q4 <- opq ("el Carxe", osm_type = "node") |>
     add_osm_feature (key = "natural", value = "peak") |>
     add_osm_feature (key = "!ele")
+cat(opq_string(q4))
+
+# Get objects with keys (`natural` OR `waterway`) AND `name`
+q_keys <- opq ("Badia del Vallès", osm_types = "nwr", out = "tags") |>
+    add_osm_features (features = list (natural = NULL, waterway = NULL)) |>
+    add_osm_feature (key = "name")
+cat(opq_string(q_keys))
 }
 }
 \references{

--- a/man/add_osm_features.Rd
+++ b/man/add_osm_features.Rd
@@ -62,7 +62,7 @@ q <- opq ("portsmouth usa") |>
         "\"amenity\"=\"restaurant\"",
         "\"amenity\"=\"pub\""
     ))
-cat(opq_string(q))
+cat (opq_string (q))
 # This extracts in a single query the same result as the following:
 q1 <- opq ("portsmouth usa") |>
     add_osm_feature (
@@ -77,7 +77,7 @@ c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
 q_keys <- opq ("Badia del Vallès", osm_types = "nwr", out = "tags") |>
     add_osm_features (features = list (natural = NULL, waterway = NULL)) |>
     add_osm_feature (key = "name")
-cat(opq_string(q_keys))
+cat (opq_string (q_keys))
 }
 }
 \references{

--- a/man/add_osm_features.Rd
+++ b/man/add_osm_features.Rd
@@ -62,6 +62,7 @@ q <- opq ("portsmouth usa") |>
         "\"amenity\"=\"restaurant\"",
         "\"amenity\"=\"pub\""
     ))
+cat(opq_string(q))
 # This extracts in a single query the same result as the following:
 q1 <- opq ("portsmouth usa") |>
     add_osm_feature (
@@ -71,6 +72,12 @@ q1 <- opq ("portsmouth usa") |>
 q2 <- opq ("portsmouth usa") |>
     add_osm_feature (key = "amenity", value = "pub")
 c (osmdata_sf (q1), osmdata_sf (q2)) # all restaurants OR pubs
+
+# Get objects with keys (`natural` OR `waterway`) AND `name`
+q_keys <- opq ("Badia del Vallès", osm_types = "nwr", out = "tags") |>
+    add_osm_features (features = list (natural = NULL, waterway = NULL)) |>
+    add_osm_feature (key = "name")
+cat(opq_string(q_keys))
 }
 }
 \references{


### PR DESCRIPTION
Show the undocumented use of `osm_add_features()` with key and without a value. Also show the combination of `osm_add_features() |> osm_add_feature()` to ask for (`natural` OR `waterway`) AND `name`