### PR TITLE
replace attributes in getbb sf_polygon for #377

### DIFF
--- a/R/getbb.R
+++ b/R/getbb.R
@@ -309,9 +309,10 @@ getbb <- function (place_name,
             # sort geometries following Nominatim order
             ord_poly <- match (obj_id, poly_id)
             geometry <- ret_poly$geometry [ord_poly]
+            # sub-setting without 'sf' loaded removes attributes:
+            attributes (geometry) <- attributes (ret_poly$geometry)
 
-            requireNamespace ("sf", quietly = TRUE)
-            ret <- sf::st_sf (ret, geometry = sf::st_sfc (geometry))
+            ret <- make_sf (ret, geometry)
         }
     }
 

--- a/R/getbb.R
+++ b/R/getbb.R
@@ -310,7 +310,8 @@ getbb <- function (place_name,
             ord_poly <- match (obj_id, poly_id)
             geometry <- ret_poly$geometry [ord_poly]
 
-            ret <- make_sf (ret, geometry)
+            requireNamespace ("sf", quietly = TRUE)
+            ret <- sf::st_sf (ret, geometry = sf::st_sfc (geometry))
         }
     }
 


### PR DESCRIPTION
@jmaspons Without this it fails on, for example, `getbb("london uk", format_out = "polygon")`. That's because of these lines:
https://github.com/ropensci/osmdata/blob/d926e6faca57d0ad9ff5cb9686bcc3d8e0c740ba/R/getbb.R#L310-L311,
which sub-set `ret_poly$geometry`. In that case `order_poly` is 2:1, and the sub-setting removes all attributes when `sf` is not loaded. (`sf` has it's own sub-setting generic, so all works if and only if that namespace is loaded.) This then leads to this:
https://github.com/ropensci/osmdata/blob/d926e6faca57d0ad9ff5cb9686bcc3d8e0c740ba/R/get-osmdata-sf.R#L139-L142,
but those attributes have been removed by the sub-setting, and so `sf_column` is `integer(0)`, and `make_sf()` fails from that point on.