### PR TITLE
Avoid skipping test-unname.R for test-coverage action

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-name: test-coverage.yaml
+name: test-coverage
 
 permissions: read-all
 


### PR DESCRIPTION
Perhaps skipped because of the workflow name mismatch

https://github.com/ropensci/osmdata/blob/3d551f38ba8d58bb3c1577a20ece25115ec53403/tests/testthat/test-unname.R#L3-L4