### PR TITLE
Update URLs of public Overpass API instances

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,7 +8,7 @@
     ## Added and edited code here by JimShady to use random API each time.
     available_apis <- c (
         "https://overpass-api.de/api/interpreter",
-        "https://overpass.kumi.systems/api/interpreter"
+        "https://maps.mail.ru/osm/tools/overpass/api/interpreter"
     )
 
     op.osmdata <- list ( # nolint
@@ -64,15 +64,7 @@ get_overpass_url <- function () {
 #' are:
 #' \itemize{
 #' \item "https://overpass-api.de/api/interpreter" (default)
-#' \item "https://overpass.kumi.systems/api/interpreter"
-#' \item "https://overpass.osm.rambler.ru/cgi/interpreter"
-#' \item "https://api.openstreetmap.fr/oapi/interpreter"
-#' \item "https://overpass.osm.vi-di.fr/api/interpreter"
-#' }
-#' Additional APIs with limited local coverage include:
-#' \itemize{
-#' \item "https://overpass.osm.ch/api/interpreter" (Switzerland)
-#' \item "https://overpass.openstreetmap.ie/api/interpreter" (Ireland)
+#' \item "https://maps.mail.ru/osm/tools/overpass/api/interpreter"
 #' }
 #'
 #' For further details, see

--- a/man/set_overpass_url.Rd
+++ b/man/set_overpass_url.Rd
@@ -17,15 +17,7 @@ Set the URL of the specified overpass API. Possible APIs with global coverage
 are:
 \itemize{
 \item "https://overpass-api.de/api/interpreter" (default)
-\item "https://overpass.kumi.systems/api/interpreter"
-\item "https://overpass.osm.rambler.ru/cgi/interpreter"
-\item "https://api.openstreetmap.fr/oapi/interpreter"
-\item "https://overpass.osm.vi-di.fr/api/interpreter"
-}
-Additional APIs with limited local coverage include:
-\itemize{
-\item "https://overpass.osm.ch/api/interpreter" (Switzerland)
-\item "https://overpass.openstreetmap.ie/api/interpreter" (Ireland)
+\item "https://maps.mail.ru/osm/tools/overpass/api/interpreter"
 }
 }
 \details{

--- a/vignettes/osmdata.Rmd
+++ b/vignettes/osmdata.Rmd
@@ -192,7 +192,7 @@ base url:
 
 ```{r}
 get_overpass_url ()
-new_url <- "https://overpass.openstreetmap.ie/api/interpreter"
+new_url <- "https://maps.mail.ru/osm/tools/overpass/api/interpreter"
 ```
 
 ```{r, eval=FALSE}


### PR DESCRIPTION
As agreed in https://github.com/ropensci/osmdata/issues/427, I am opening a PR here with the updated URLs. Besides the default `"https://overpass-api.de/api/interpreter"`, only `"https://maps.mail.ru/osm/tools/overpass/api/interpreter"` seems to work with a usage policy comparable to the default instance.

I also suggested dropping the region-specific instances from the `set_overpass_url()` docs, especially because their usage policies are not specific enough on rate limits. The user can still go to https://wiki.openstreetmap.org/wiki/Overpass_API and get more information about other instances.

I do not know if URL checks should be done in `.onLoad()`, so I am not sure how to make this future-proof. This should work for now, but the issue might arise again if the instances change.